### PR TITLE
fix(timer): resolve 405 when starting a timer from tasks/project views

### DIFF
--- a/app/templates/tasks/edit.html
+++ b/app/templates/tasks/edit.html
@@ -247,7 +247,7 @@
                         </a>
                         
                         {% if task.status == 'todo' or task.status == 'in_progress' %}
-                        <a href="{{ url_for('timer.start_timer', project_id=task.project_id, task_id=task.id) }}" class="btn btn-success btn-sm">
+                        <a href="{{ url_for('timer.start_timer_for_project', project_id=task.project_id, task_id=task.id) }}" class="btn btn-success btn-sm">
                             <i class="fas fa-play me-2"></i>Start Timer
                         </a>
                         {% endif %}

--- a/app/templates/tasks/list.html
+++ b/app/templates/tasks/list.html
@@ -203,7 +203,7 @@
                                 </a></li>
                                 {% endif %}
                                 <li><hr class="dropdown-divider"></li>
-                                <li><a class="dropdown-item" href="{{ url_for('timer.start_timer', project_id=task.project_id, task_id=task.id) }}">
+                                <li><a class="dropdown-item" href="{{ url_for('timer.start_timer_for_project', project_id=task.project_id, task_id=task.id) }}">
                                     <i class="fas fa-play me-2"></i>Start Timer
                                 </a></li>
                             </ul>
@@ -300,7 +300,7 @@
                             <i class="fas fa-eye me-2"></i>View Details
                         </a>
                         {% if task.status == 'todo' or task.status == 'in_progress' %}
-                        <a href="{{ url_for('timer.start_timer', project_id=task.project_id, task_id=task.id) }}" class="btn btn-success btn-sm">
+                        <a href="{{ url_for('timer.start_timer_for_project', project_id=task.project_id, task_id=task.id) }}" class="btn btn-success btn-sm">
                             <i class="fas fa-play me-2"></i>Start Timer
                         </a>
                         {% endif %}

--- a/app/templates/tasks/my_tasks.html
+++ b/app/templates/tasks/my_tasks.html
@@ -210,7 +210,7 @@
                                 </a></li>
                                 {% endif %}
                                 <li><hr class="dropdown-divider"></li>
-                                <li><a class="dropdown-item" href="{{ url_for('timer.start_timer', project_id=task.project_id, task_id=task.id) }}">
+                                <li><a class="dropdown-item" href="{{ url_for('timer.start_timer_for_project', project_id=task.project_id, task_id=task.id) }}">
                                     <i class="fas fa-play me-2"></i>Start Timer
                                 </a></li>
                             </ul>
@@ -321,7 +321,7 @@
                             <i class="fas fa-eye me-2"></i>View Details
                         </a>
                         {% if task.status == 'todo' or task.status == 'in_progress' %}
-                        <a href="{{ url_for('timer.start_timer', project_id=task.project_id, task_id=task.id) }}" class="btn btn-success btn-sm">
+                        <a href="{{ url_for('timer.start_timer_for_project', project_id=task.project_id, task_id=task.id) }}" class="btn btn-success btn-sm">
                             <i class="fas fa-play me-2"></i>Start Timer
                         </a>
                         {% endif %}

--- a/app/templates/tasks/overdue.html
+++ b/app/templates/tasks/overdue.html
@@ -97,7 +97,7 @@
                             <i class="fas fa-edit"></i> Edit
                         </a>
                         {% endif %}
-                        <a href="{{ url_for('timer.start_timer', project_id=task.project.id, task_id=task.id) }}" 
+                        <a href="{{ url_for('timer.start_timer_for_project', project_id=task.project.id, task_id=task.id) }}" 
                            class="btn btn-outline-success">
                             <i class="fas fa-play"></i> Timer
                         </a>

--- a/app/templates/tasks/view.html
+++ b/app/templates/tasks/view.html
@@ -50,7 +50,7 @@
                         <div class="col-lg-4 col-md-5">
                             <div class="d-flex flex-column gap-2">
                                 {% if task.status == 'todo' or task.status == 'in_progress' %}
-                                <a href="{{ url_for('timer.start_timer', project_id=task.project_id, task_id=task.id) }}" class="btn btn-success">
+                                <a href="{{ url_for('timer.start_timer_for_project', project_id=task.project_id, task_id=task.id) }}" class="btn btn-success">
                                     <i class="fas fa-play me-2"></i>Start Timer
                                 </a>
                                 {% endif %}

--- a/templates/projects/view.html
+++ b/templates/projects/view.html
@@ -37,7 +37,7 @@
                     <a href="{{ url_for('main.dashboard') }}" class="btn btn-outline-secondary">
                         <i class="fas fa-arrow-left me-1"></i> Back
                     </a>
-                    <a href="{{ url_for('timer.start_timer', project_id=project.id) }}" class="btn btn-primary">
+                    <a href="{{ url_for('timer.start_timer_for_project', project_id=project.id) }}" class="btn btn-primary">
                         <i class="fas fa-play me-1"></i> Start Timer
                     </a>
                 </div>
@@ -227,7 +227,7 @@
                                         <a href="{{ url_for('tasks.view_task', task_id=task.id) }}" class="btn btn-outline-primary btn-sm">
                                             <i class="fas fa-eye"></i>
                                         </a>
-                                        <a href="{{ url_for('timer.start_timer', project_id=task.project.id, task_id=task.id) }}" 
+                                        <a href="{{ url_for('timer.start_timer_for_project', project_id=task.project.id, task_id=task.id) }}" 
                                            class="btn btn-outline-success btn-sm">
                                             <i class="fas fa-play"></i>
                                         </a>


### PR DESCRIPTION
Use GET route `timer.start_timer_for_project` instead of POST-only `timer.start_timer` in task and project templates. This fixes “405 Method Not Allowed” when starting a timer from /tasks and /tasks/<id>, and from the project view.