### PR TITLE
feat(reports): add Finished Tasks report with per-task hours and filters

### DIFF
--- a/templates/reports/index.html
+++ b/templates/reports/index.html
@@ -106,6 +106,9 @@
                         <a href="{{ url_for('reports.project_report') }}" class="btn btn-primary">
                             <i class="fas fa-chart-bar"></i> Project Report
                         </a>
+                        <a href="{{ url_for('reports.task_report') }}" class="btn btn-outline-primary mt-2">
+                            <i class="fas fa-tasks"></i> Finished Tasks Report
+                        </a>
                     </div>
                 </div>
             </div>

--- a/templates/reports/task_report.html
+++ b/templates/reports/task_report.html
@@ -1,0 +1,202 @@
+{% extends "base.html" %}
+
+{% block title %}Finished Tasks Report - {{ app_name }}{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="d-flex justify-content-between align-items-center mb-4">
+                <div>
+                    <nav aria-label="breadcrumb">
+                        <ol class="breadcrumb">
+                            <li class="breadcrumb-item"><a href="{{ url_for('reports.reports') }}">Reports</a></li>
+                            <li class="breadcrumb-item active">Finished Tasks</li>
+                        </ol>
+                    </nav>
+                    <h1 class="h3 mb-0">
+                        <i class="fas fa-tasks text-primary"></i> Finished Tasks Report
+                    </h1>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Filters -->
+    <div class="row mb-4">
+        <div class="col-12">
+            <div class="card border-0 shadow-sm">
+                <div class="card-header bg-white">
+                    <h5 class="mb-0">
+                        <i class="fas fa-filter"></i> Filters
+                    </h5>
+                </div>
+                <div class="card-body">
+                    <form method="GET" class="row g-3">
+                        <div class="col-md-3">
+                            <label for="start_date" class="form-label">Start Date</label>
+                            <input type="date" class="form-control" id="start_date" name="start_date" 
+                                   value="{{ start_date or '' }}">
+                        </div>
+                        <div class="col-md-3">
+                            <label for="end_date" class="form-label">End Date</label>
+                            <input type="date" class="form-control" id="end_date" name="end_date" 
+                                   value="{{ end_date or '' }}">
+                        </div>
+                        <div class="col-md-3">
+                            <label for="project" class="form-label">Project</label>
+                            <select class="form-select" id="project" name="project_id">
+                                <option value="">All Projects</option>
+                                {% for project in projects %}
+                                <option value="{{ project.id }}" {% if selected_project|int == project.id %}selected{% endif %}>
+                                    {{ project.name }}
+                                </option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="col-md-3">
+                            <label for="user" class="form-label">User</label>
+                            <select class="form-select" id="user" name="user_id">
+                                <option value="">All Users</option>
+                                {% for user in users %}
+                                <option value="{{ user.id }}" {% if selected_user|int == user.id %}selected{% endif %}>
+                                    {{ user.display_name }}
+                                </option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="col-12">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fas fa-search"></i> Apply Filters
+                            </button>
+                            <a href="{{ url_for('reports.task_report') }}" class="btn btn-outline-secondary">
+                                <i class="fas fa-times"></i> Clear
+                            </a>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Summary Statistics -->
+    <div class="row mb-4">
+        <div class="col-md-3 col-sm-6 mb-3">
+            <div class="card border-0 shadow-sm h-100 summary-card">
+                <div class="card-body p-3">
+                    <div class="d-flex align-items-center">
+                        <div class="flex-shrink-0">
+                            <div class="summary-icon bg-primary bg-opacity-10 text-primary">
+                                <i class="fas fa-tasks"></i>
+                            </div>
+                        </div>
+                        <div class="flex-grow-1 ms-3">
+                            <div class="summary-label">Finished Tasks</div>
+                            <div class="summary-value">{{ summary.tasks_count }}</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3 col-sm-6 mb-3">
+            <div class="card border-0 shadow-sm h-100 summary-card">
+                <div class="card-body p-3">
+                    <div class="d-flex align-items-center">
+                        <div class="flex-shrink-0">
+                            <div class="summary-icon bg-success bg-opacity-10 text-success">
+                                <i class="fas fa-clock"></i>
+                            </div>
+                        </div>
+                        <div class="flex-grow-1 ms-3">
+                            <div class="summary-label">Total Hours</div>
+                            <div class="summary-value">{{ "%.2f"|format(summary.total_hours) }}h</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Finished Tasks Table -->
+    <div class="row">
+        <div class="col-12">
+            <div class="card shadow-sm border-0">
+                <div class="card-header bg-white py-3">
+                    <h5 class="mb-0">
+                        <i class="fas fa-list"></i> Finished Tasks ({{ tasks|length }})
+                    </h5>
+                </div>
+                <div class="card-body p-0">
+                    {% if tasks %}
+                    <div class="table-responsive">
+                        <table class="table table-hover mb-0">
+                            <thead class="table-light">
+                                <tr>
+                                    <th>Task</th>
+                                    <th>Project</th>
+                                    <th>Assignee</th>
+                                    <th>Completed</th>
+                                    <th>Hours</th>
+                                    <th>Entries</th>
+                                    <th>Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for row in tasks %}
+                                <tr>
+                                    <td>
+                                        <div>
+                                            <strong>{{ row.task.name }}</strong>
+                                            {% if row.task.description %}
+                                            <br><small class="text-muted">{{ row.task.description[:60] }}{% if row.task.description|length > 60 %}...{% endif %}</small>
+                                            {% endif %}
+                                        </div>
+                                    </td>
+                                    <td>
+                                        <a href="{{ url_for('projects.view_project', project_id=row.project.id) }}">
+                                            {{ row.project.name }}
+                                        </a>
+                                    </td>
+                                    <td>
+                                        {% if row.assignee %}
+                                        {{ row.assignee.display_name }}
+                                        {% else %}
+                                        <span class="text-muted">Unassigned</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if row.completed_at %}
+                                        {{ row.completed_at.strftime('%Y-%m-%d') }}
+                                        {% else %}
+                                        <span class="text-muted">-</span>
+                                        {% endif %}
+                                    </td>
+                                    <td><strong>{{ "%.2f"|format(row.hours) }}h</strong></td>
+                                    <td>{{ row.entries_count }}</td>
+                                    <td>
+                                        <a href="{{ url_for('tasks.view_task', task_id=row.task.id) }}" class="btn btn-sm btn-outline-primary">
+                                            <i class="fas fa-eye"></i>
+                                        </a>
+                                    </td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                    {% else %}
+                    <div class="text-center py-5">
+                        <div class="empty-state">
+                            <i class="fas fa-tasks fa-3x text-muted mb-3"></i>
+                            <h5 class="text-muted">No Finished Tasks Found</h5>
+                            <p class="text-muted">Try adjusting your filters.</p>
+                        </div>
+                    </div>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+


### PR DESCRIPTION
- New route: GET /reports/tasks
  - Lists tasks with status "done" completed within the selected date range
  - Filters: project_id, user_id, start_date, end_date (defaults to last 30 days)
  - Aggregates hours per task from matching TimeEntry records
  - Shows assignee, completion date, total hours, and entry count per task
- UI: new template templates/reports/task_report.html with filters, summary cards, and results table
- Navigation: add “Finished Tasks Report” link under Project Reports on templates/reports/index.html
- Consistent styling and behavior with existing project/user reports
- No schema changes; login required