### PR TITLE
feat(ui): dark mode fixes and Log Time UX aligned with invoices

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -15,6 +15,7 @@ class User(UserMixin, db.Model):
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
     last_login = db.Column(db.DateTime, nullable=True)
     is_active = db.Column(db.Boolean, default=True, nullable=False)
+    theme_preference = db.Column(db.String(10), default=None, nullable=True)  # 'light' | 'dark' | None=system
     
     # Relationships
     time_entries = db.relationship('TimeEntry', backref='user', lazy='dynamic', cascade='all, delete-orphan')

--- a/app/static/base.css
+++ b/app/static/base.css
@@ -25,6 +25,35 @@
     --mobile-card-spacing: 1rem;
 }
 
+/* Dark theme variables */
+[data-theme="dark"] {
+    --primary-color: #60a5fa;
+    --primary-dark: #3b82f6;
+    --primary-light: #93c5fd;
+    --secondary-color: #94a3b8;
+    --success-color: #10b981;
+    --danger-color: #ef4444;
+    --warning-color: #f59e0b;
+    --info-color: #38bdf8;
+    --dark-color: #0b1220;
+    --light-color: #0f172a;
+    --border-color: #1f2a44;
+    --text-primary: #e5e7eb;
+    --text-secondary: #cbd5e1;
+    --text-muted: #94a3b8;
+    --bg-gradient: linear-gradient(135deg, #0b1220 0%, #0f172a 100%);
+    --card-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.6), 0 1px 2px 0 rgba(0, 0, 0, 0.5);
+    --card-shadow-hover: 0 8px 24px rgba(0, 0, 0, 0.6);
+    /* Bootstrap variable overrides for dark theme */
+    --bs-body-bg: #0b1220;
+    --bs-body-color: #e5e7eb;
+    --bs-dropdown-bg: #0f172a;
+    --bs-dropdown-link-color: #cbd5e1;
+    --bs-dropdown-link-hover-bg: #111827;
+    --bs-card-bg: #0f172a;
+    --bs-card-border-color: #1f2a44;
+}
+
 * {
     box-sizing: border-box;
 }
@@ -46,6 +75,11 @@ body {
     font-size: 0.95rem;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+}
+
+/* Base backgrounds in dark theme */
+[data-theme="dark"] body {
+    background: #0b1220;
 }
 
 main {
@@ -81,6 +115,30 @@ main {
     overflow: visible;
     margin-bottom: var(--card-spacing);
 }
+
+[data-theme="dark"] .card,
+[data-theme="dark"] .modal-content,
+[data-theme="dark"] .dropdown-menu,
+[data-theme="dark"] .mobile-table-row,
+[data-theme="dark"] .table tr {
+    background: #0f172a !important;
+    color: var(--text-secondary);
+    border-color: var(--border-color) !important;
+}
+
+[data-theme="dark"] .card-header,
+[data-theme="dark"] .alert,
+[data-theme="dark"] .table td,
+[data-theme="dark"] .table th {
+    background: #0f172a;
+    color: var(--text-secondary);
+    border-color: var(--border-color);
+}
+
+[data-theme="dark"] .card a:hover .card-body { background-color: #111827; }
+[data-theme="dark"] .dropdown-item { background-color: #0f172a !important; color: var(--text-secondary) !important; }
+[data-theme="dark"] .dropdown-item:hover { background-color: #111827 !important; }
+[data-theme="dark"] .navbar .dropdown-menu { --bs-dropdown-bg: #0f172a; }
 
 .card:last-child {
     margin-bottom: 0;
@@ -257,6 +315,27 @@ main {
     color: var(--text-primary);
 }
 
+[data-theme="dark"] .btn-outline-secondary {
+    border-color: var(--border-color);
+    color: var(--text-secondary);
+}
+[data-theme="dark"] .btn-outline-secondary:hover {
+    background: #111827;
+    border-color: var(--text-secondary);
+    color: var(--text-primary);
+}
+/* Outline light buttons on dark backgrounds */
+[data-theme="dark"] .btn-outline-light {
+    border: 2px solid #e5e7eb;
+    color: #e5e7eb;
+    background: transparent;
+}
+[data-theme="dark"] .btn-outline-light:hover {
+    background: #e5e7eb;
+    color: #0b1220;
+    border-color: #e5e7eb;
+}
+
 /* Keep outline secondary buttons light when opened/active */
 .btn-outline-secondary:focus,
 .btn-outline-secondary:active,
@@ -289,6 +368,15 @@ main {
     background: white;
     min-height: 52px;
 }
+
+[data-theme="dark"] .form-control,
+[data-theme="dark"] .form-select {
+    background: #0f172a;
+    color: var(--text-primary);
+}
+[data-theme="dark"] .form-text { color: var(--text-muted); }
+[data-theme="dark"] .form-control::placeholder { color: #64748b; }
+[data-theme="dark"] .form-select option { background: #0f172a; color: var(--text-primary); }
 
 .form-control:focus, .form-select:focus {
     border-color: var(--primary-color);
@@ -338,6 +426,10 @@ main {
     transform: scale(1.01);
 }
 
+[data-theme="dark"] .table tbody tr:hover {
+    background: #111827;
+}
+
 /* Consistent table action groups */
 .table td,
 .table th {
@@ -352,6 +444,29 @@ main {
     display: inline-flex;
     align-items: center;
     flex-wrap: nowrap;
+}
+
+/* Ensure grouped action buttons sit flush with no gaps */
+.btn-group > .btn,
+.btn-group .btn-action {
+    margin: 0;
+}
+.btn-group > .btn + .btn,
+.btn-group > .btn + .btn-group,
+.btn-group > .btn-group + .btn,
+.btn-group > .btn-group + .btn-group {
+    margin-left: -1px; /* collapse borders */
+}
+.btn-group .btn-action {
+    border-radius: 0;
+}
+.btn-group .btn-action:first-child {
+    border-top-left-radius: var(--border-radius-sm);
+    border-bottom-left-radius: var(--border-radius-sm);
+}
+.btn-group .btn-action:last-child {
+    border-top-right-radius: var(--border-radius-sm);
+    border-bottom-right-radius: var(--border-radius-sm);
 }
 
 .table td .btn-group .btn {
@@ -383,6 +498,43 @@ main {
     justify-content: center;
     gap: 0.35rem;
 }
+/* Action buttons in dark theme */
+[data-theme="dark"] .btn-action {
+    background: #0f172a;
+    border-color: var(--border-color);
+    color: var(--text-secondary);
+}
+[data-theme="dark"] .btn-action:hover { background: #111827; }
+[data-theme="dark"] .btn-action--view {
+    color: #93c5fd;
+    border-color: rgba(59, 130, 246, 0.35);
+}
+[data-theme="dark"] .btn-action--view:hover { background: rgba(59, 130, 246, 0.08); }
+[data-theme="dark"] .btn-action--edit {
+    color: var(--text-secondary);
+    border-color: var(--border-color);
+}
+[data-theme="dark"] .btn-action--edit:hover { background: #111827; }
+[data-theme="dark"] .btn-action--danger {
+    color: #fca5a5;
+    border-color: rgba(220, 38, 38, 0.45);
+}
+[data-theme="dark"] .btn-action--danger:hover { background: rgba(220, 38, 38, 0.12); }
+[data-theme="dark"] .btn-action--success {
+    color: #86efac;
+    border-color: rgba(16, 185, 129, 0.45);
+}
+[data-theme="dark"] .btn-action--success:hover { background: rgba(16, 185, 129, 0.12); }
+[data-theme="dark"] .btn-action--warning {
+    color: #fcd34d;
+    border-color: rgba(245, 158, 11, 0.55);
+}
+[data-theme="dark"] .btn-action--warning:hover { background: rgba(245, 158, 11, 0.12); }
+[data-theme="dark"] .btn-action--more {
+    color: #93c5fd;
+    border-color: rgba(59, 130, 246, 0.45);
+}
+[data-theme="dark"] .btn-action--more:hover { background: rgba(59, 130, 246, 0.12); }
 
 .btn-action i { font-size: 0.95rem; }
 
@@ -455,6 +607,24 @@ main {
     min-height: 70px;
 }
 
+[data-theme="dark"] .navbar {
+    background: #0b1220 !important;
+    border-bottom-color: var(--border-color);
+}
+[data-theme="dark"] .navbar-collapse {
+    background: #0b1220 !important;
+}
+[data-theme="dark"] .navbar .navbar-toggler {
+    border-color: var(--border-color);
+}
+[data-theme="dark"] .navbar .navbar-toggler-icon {
+    filter: invert(1) brightness(0.9);
+}
+[data-theme="dark"] .navbar .nav-link { color: var(--text-secondary) !important; }
+[data-theme="dark"] .navbar .nav-link.active { color: #fff !important; }
+[data-theme="dark"] .navbar .navbar-brand .text-dark { color: var(--text-primary) !important; }
+[data-theme="dark"] .mobile-tabbar { background: #0b1220; border-top: 1px solid var(--border-color); }
+
 /* Navbar shadow on scroll */
 .navbar.scrolled {
     box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12);
@@ -502,6 +672,10 @@ main {
     color: var(--primary-color) !important;
     background: var(--light-color);
     transform: translateY(-1px);
+}
+
+[data-theme="dark"] .navbar-nav .nav-link:hover {
+    background: #111827;
 }
 
 .navbar-nav .nav-link.active {
@@ -727,6 +901,26 @@ h6 { font-size: 1rem; }
     background-clip: padding-box; /* ensure solid fill to rounded corners */
 }
 
+/* Dark mode dropdown menu container */
+[data-theme="dark"] .dropdown-menu {
+    background: #0f172a !important;
+    border-color: var(--border-color);
+    box-shadow: var(--card-shadow-hover);
+}
+[data-theme="dark"] .dropdown-menu .dropdown-item {
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid rgba(255,255,255,0.04);
+}
+[data-theme="dark"] .dropdown-menu .dropdown-item:last-child {
+    border-bottom: none;
+}
+[data-theme="dark"] .dropdown-divider {
+    background-color: var(--border-color) !important;
+    opacity: 1;
+}
+[data-theme="dark"] .dropdown-item { color: var(--text-secondary) !important; }
+[data-theme="dark"] .dropdown-item:hover { background-color: #111827 !important; color: var(--text-primary) !important; }
+
 /* Ensure dropdowns inside cards stack above adjacent content */
 .card .dropdown,
 .mobile-card .dropdown {
@@ -746,6 +940,11 @@ h6 { font-size: 1rem; }
     background: #ffffff; /* solid background to avoid transparency */
     border-radius: inherit;
     z-index: -1; /* sit behind menu content but within menu stacking */
+}
+
+/* Fix white overlay in dark mode dropdown */
+[data-theme="dark"] .dropdown-menu::before {
+    background: #0f172a;
 }
 
 /* Solid hover state for items to further avoid transparency feel */
@@ -799,6 +998,10 @@ h6 { font-size: 1rem; }
     padding: 2.5rem 0;
     margin-top: 4rem;
     border-top: 1px solid var(--border-color);
+}
+
+[data-theme="dark"] .footer {
+    background: #0b1220;
 }
 
 .footer a {
@@ -886,6 +1089,85 @@ h6 { font-size: 1rem; }
     position: relative;
     background: white;
 }
+
+[data-theme="dark"] .alert { background: #0f172a; }
+[data-theme="dark"] .alert-success { background: #052e1f; color: #a7f3d0; }
+[data-theme="dark"] .alert-danger { background: #3f1d1d; color: #fecaca; }
+[data-theme="dark"] .alert-info { background: #082f49; color: #bae6fd; }
+[data-theme="dark"] .alert-warning { background: #422006; color: #fed7aa; }
+
+/* ==========================================
+   Dark theme utility & component overrides
+   ========================================== */
+
+/* Text utilities */
+[data-theme="dark"] .text-dark { color: var(--text-primary) !important; }
+[data-theme="dark"] .text-muted { color: var(--text-muted) !important; }
+[data-theme="dark"] .text-secondary { color: var(--text-secondary) !important; }
+
+/* Background utilities */
+[data-theme="dark"] .bg-white { background-color: #0f172a !important; }
+[data-theme="dark"] .bg-light { background-color: #111827 !important; }
+[data-theme="dark"] .bg-body { background-color: #0b1220 !important; }
+
+/* Borders and dividers */
+[data-theme="dark"] .border,
+[data-theme="dark"] .border-top,
+[data-theme="dark"] .border-bottom,
+[data-theme="dark"] .border-start,
+[data-theme="dark"] .border-end,
+[data-theme="dark"] hr,
+[data-theme="dark"] .dropdown-divider { border-color: var(--border-color) !important; }
+
+/* List groups */
+[data-theme="dark"] .list-group-item {
+    background-color: #0f172a;
+    color: var(--text-secondary);
+    border-color: var(--border-color);
+}
+[data-theme="dark"] .list-group-item.active {
+    background-color: var(--primary-color);
+    color: #ffffff;
+    border-color: var(--primary-dark);
+}
+
+/* Badges */
+[data-theme="dark"] .badge.bg-light {
+    background-color: #1f2937 !important;
+    color: var(--text-secondary) !important;
+    border: 1px solid var(--border-color);
+}
+
+/* Pagination */
+[data-theme="dark"] .pagination .page-link {
+    background-color: #0f172a;
+    color: var(--text-secondary);
+    border-color: var(--border-color);
+}
+[data-theme="dark"] .pagination .page-item.active .page-link {
+    background-color: var(--primary-color);
+    color: #ffffff;
+    border-color: var(--primary-dark);
+}
+[data-theme="dark"] .pagination .page-link:hover {
+    background-color: #111827;
+}
+
+/* Tables: ensure caption and muted text are readable */
+[data-theme="dark"] table caption { color: var(--text-muted); }
+
+/* Inputs toggles and checks */
+[data-theme="dark"] .form-check-input:checked {
+    background-color: var(--primary-color);
+    border-color: var(--primary-color);
+}
+
+/* In-page status badges (tasks) */
+[data-theme="dark"] .status-todo { background-color: #334155 !important; color: #cbd5e1 !important; }
+[data-theme="dark"] .status-in_progress { background-color: #3f2d0c !important; color: #fbbf24 !important; }
+[data-theme="dark"] .status-review { background-color: #1e3a8a !important; color: #dbeafe !important; }
+[data-theme="dark"] .status-done { background-color: #064e3b !important; color: #d1fae5 !important; }
+[data-theme="dark"] .status-cancelled { background-color: #7f1d1d !important; color: #fee2e2 !important; }
 
 .alert-success {
     border-color: #10b981;

--- a/app/static/mobile.css
+++ b/app/static/mobile.css
@@ -257,12 +257,14 @@
     }
     
     .navbar-collapse {
-        background: white;
-        border-top: 1px solid #e2e8f0;
+        background: var(--bs-body-bg);
+        border-top: 1px solid var(--border-color);
         margin-top: 0.75rem;
         padding: 1rem 0;
-        box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+        box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
         border-radius: 0 0 var(--mobile-border-radius) var(--mobile-border-radius);
+        position: relative;
+        z-index: 1100; /* above page content */
     }
     
     .navbar-nav .nav-link {
@@ -300,11 +302,10 @@
         float: none;
         width: 100%;
         margin: 0;
-        border: 2px solid #3b82f6 !important;
+        border: 2px solid var(--primary-color) !important;
         box-shadow: 0 8px 25px rgba(0, 0, 0, 0.25) !important;
-        background: #ffffff !important;
-        background-color: #ffffff !important; /* ensure solid bg */
-        --bs-dropdown-bg: #ffffff; /* bootstrap var override */
+        background: var(--bs-dropdown-bg, #ffffff) !important;
+        background-color: var(--bs-dropdown-bg, #ffffff) !important; /* ensure solid bg */
         border-radius: var(--mobile-border-radius);
         margin-top: 0.75rem;
         padding: 0.5rem;
@@ -323,8 +324,8 @@
         align-items: center;
         gap: 0.75rem;
         transition: all 0.3s ease;
-        color: #1e293b !important;
-        background: #ffffff !important; /* ensure solid bg for items */
+        color: var(--bs-dropdown-link-color, #1e293b) !important;
+        background: var(--bs-dropdown-bg, #ffffff) !important; /* ensure solid bg for items */
         border: none;
         text-decoration: none;
         font-weight: 600;
@@ -333,8 +334,8 @@
     }
     
     .dropdown-item:hover {
-        background: #f1f5f9 !important;
-        color: #0f172a !important;
+        background: var(--bs-dropdown-link-hover-bg, #f1f5f9) !important;
+        color: var(--text-primary, #0f172a) !important;
         transform: translateX(4px);
         box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
     }
@@ -404,8 +405,8 @@
     .navbar .dropdown-menu.show {
         display: block !important;
         transform: none !important;
-        background: #ffffff !important;
-        border: 2px solid #3b82f6 !important;
+        background: var(--bs-dropdown-bg, #ffffff) !important;
+        border: 2px solid var(--primary-color) !important;
         box-shadow: 0 8px 25px rgba(0, 0, 0, 0.25) !important;
     }
     
@@ -414,8 +415,8 @@
     .navbar .dropdown-menu.show,
     .navbar .dropdown-menu[data-bs-popper="static"] {
         display: block !important;
-        background: #ffffff !important;
-        border: 2px solid #3b82f6 !important;
+        background: var(--bs-dropdown-bg, #ffffff) !important;
+        border: 2px solid var(--primary-color) !important;
         box-shadow: 0 8px 25px rgba(0, 0, 0, 0.25) !important;
         z-index: 9999 !important;
     }
@@ -775,6 +776,15 @@
     }
     .mobile-tabbar .tab-item.active {
         color: #3b82f6;
+    }
+}
+
+/* Respect forced light theme on mobile if explicitly set */
+@media (prefers-color-scheme: dark) {
+    html[data-theme="light"] .navbar,
+    html[data-theme="light"] .mobile-tabbar {
+        background: #ffffff !important;
+        border-color: #e2e8f0 !important;
     }
 }
 

--- a/app/templates/auth/profile.html
+++ b/app/templates/auth/profile.html
@@ -10,6 +10,10 @@
 		<a href="{{ url_for('auth.edit_profile') }}" class="btn btn-outline-light btn-sm">
 			<i class="fas fa-edit"></i> Edit Profile
 		</a>
+		<button id="theme-toggle" class="btn btn-outline-secondary btn-sm">
+			<i class="fas fa-moon me-1"></i>
+			Toggle Theme
+		</button>
 		{% endset %}
 		{{ page_header('fas fa-user-circle', 'Your Profile', 'Manage your account details', actions) }}
 	</div>
@@ -54,3 +58,44 @@
 {% endblock %}
 
 
+{% block extra_js %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+	const storageKey = 'tt-theme';
+	const btn = document.getElementById('theme-toggle');
+	const meta = document.getElementById('meta-theme-color');
+	if (!btn) return;
+
+	function applyTheme(theme) {
+		document.documentElement.setAttribute('data-theme', theme);
+		if (meta) meta.setAttribute('content', theme === 'dark' ? '#0b1220' : '#3b82f6');
+		const icon = btn.querySelector('i');
+		if (icon) icon.className = theme === 'dark' ? 'fas fa-sun me-1' : 'fas fa-moon me-1';
+	}
+
+	function currentTheme() {
+		return document.documentElement.getAttribute('data-theme') || 'light';
+	}
+
+	async function saveThemeToUser(value) {
+		try {
+			await fetch('{{ url_for("auth.update_theme_preference") }}', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ theme: value })
+			});
+		} catch (e) {}
+	}
+
+	// Initialize icon state
+	applyTheme(currentTheme());
+
+	btn.addEventListener('click', async function() {
+		const next = currentTheme() === 'dark' ? 'light' : 'dark';
+		localStorage.setItem(storageKey, next);
+		applyTheme(next);
+		await saveThemeToUser(next);
+	});
+});
+</script>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -6,7 +6,8 @@
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
-    <meta name="theme-color" content="#3b82f6">
+    <meta name="theme-color" content="#3b82f6" id="meta-theme-color">
+    <meta id="user-theme-pref" data-user-theme="{{ current_user.theme_preference if current_user.is_authenticated else '' }}">
     <title>{% block title %}{{ app_name }}{% endblock %}</title>
     
     <!-- Favicon -->
@@ -29,6 +30,28 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='mobile.css') }}">
     
     {% block extra_css %}{% endblock %}
+    <script>
+        (function() {
+            try {
+                const storageKey = 'tt-theme';
+                const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+                const saved = localStorage.getItem(storageKey);
+                const userMeta = document.getElementById('user-theme-pref');
+                const serverPrefRaw = userMeta ? (userMeta.getAttribute('data-user-theme') || '').trim().toLowerCase() : '';
+                const serverPref = (serverPrefRaw === 'light' || serverPrefRaw === 'dark') ? serverPrefRaw : null;
+                const theme = serverPref || saved || (prefersDark ? 'dark' : 'light');
+                const root = document.documentElement;
+                root.setAttribute('data-theme', theme);
+                if (serverPref) {
+                    root.setAttribute('data-theme-locked', 'user');
+                } else if (saved) {
+                    root.setAttribute('data-theme-locked', 'local');
+                }
+                const meta = document.getElementById('meta-theme-color');
+                if (meta) meta.setAttribute('content', theme === 'dark' ? '#0b1220' : '#3b82f6');
+            } catch (e) {}
+        })();
+    </script>
 </head>
 <body>
     <!-- Enhanced Navigation -->
@@ -243,6 +266,7 @@
 
         // Use Bootstrap's default dropdown behavior; no custom backdrop
     </script>
+    <!-- Theme toggle logic moved to settings/profile; base keeps only initial theme setup above -->
 
     {% if current_user.is_authenticated %}
     <!-- Socket.IO only for authenticated users -->

--- a/migrations/versions/003_add_user_theme_preference.py
+++ b/migrations/versions/003_add_user_theme_preference.py
@@ -1,0 +1,20 @@
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '003'
+down_revision = '002'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('users') as batch_op:
+        batch_op.add_column(sa.Column('theme_preference', sa.String(length=10), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('users') as batch_op:
+        batch_op.drop_column('theme_preference')
+
+

--- a/templates/admin/settings.html
+++ b/templates/admin/settings.html
@@ -155,6 +155,8 @@
                                 <input type="text" class="form-control" id="currency" name="currency" value="{{ settings.currency if settings else 'EUR' }}" placeholder="e.g. EUR">
                             </div>
 
+                            
+
                             <div class="col-md-6">
                                 <label class="form-label" for="rounding_minutes">Rounding (minutes)</label>
                                 <input type="number" min="0" step="1" class="form-control" id="rounding_minutes" name="rounding_minutes" value="{{ settings.rounding_minutes if settings else 1 }}">

--- a/templates/clients/list.html
+++ b/templates/clients/list.html
@@ -160,8 +160,9 @@
 .badge-pill { border-radius: 9999px; }
 .badge-soft-primary { background: rgba(59,130,246,0.12); color: var(--primary-color); border: 1px solid rgba(59,130,246,0.25); }
 .empty-state { padding: 2rem; }
-.btn-group .btn { border-radius: 6px !important; }
-.btn-group .btn:not(:last-child) { margin-right: 2px; }
+.btn-group .btn { border-radius: 0 !important; margin-right: 0 !important; }
+.btn-group .btn:first-child { border-top-left-radius: 6px !important; border-bottom-left-radius: 6px !important; }
+.btn-group .btn:last-child { border-top-right-radius: 6px !important; border-bottom-right-radius: 6px !important; }
 @media (max-width: 768px) {
   .table-responsive { font-size: 14px; }
   .btn-group .btn { padding: 0.375rem 0.5rem; font-size: 12px; }

--- a/templates/invoices/list.html
+++ b/templates/invoices/list.html
@@ -346,13 +346,9 @@
     letter-spacing: 0.5px;
 }
 
-.btn-group .btn {
-    border-radius: 6px !important;
-}
-
-.btn-group .btn:not(:last-child) {
-    margin-right: 2px;
-}
+.btn-group .btn { border-radius: 0 !important; margin-right: 0 !important; }
+.btn-group .btn:first-child { border-top-left-radius: 6px !important; border-bottom-left-radius: 6px !important; }
+.btn-group .btn:last-child { border-top-right-radius: 6px !important; border-bottom-right-radius: 6px !important; }
 
 .empty-state {
     padding: 2rem;

--- a/templates/timer/manual_entry.html
+++ b/templates/timer/manual_entry.html
@@ -19,10 +19,15 @@
     <div class="row">
         <div class="col-lg-8">
             <div class="card shadow-sm border-0">
-                <div class="card-header py-3 bg-primary text-white">
-                    <h6 class="m-0 font-weight-bold">
-                        <i class="fas fa-plus me-2"></i>Manual Entry
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h6 class="m-0">
+                        <i class="fas fa-clock me-2 text-primary"></i>Manual Entry
                     </h6>
+                    <div class="d-none d-md-flex gap-2">
+                        <a href="{{ url_for('timer.manual_entry') }}" class="btn btn-sm btn-outline-secondary">
+                            <i class="fas fa-rotate-right me-1"></i> Reset
+                        </a>
+                    </div>
                 </div>
                 <div class="card-body">
                     <form method="POST" action="{{ url_for('timer.manual_entry') }}">
@@ -124,9 +129,14 @@
                             <a href="{{ url_for('main.dashboard') }}" class="btn btn-outline-secondary mb-2 mb-md-0">
                                 <i class="fas fa-arrow-left me-1"></i> Back
                             </a>
-                            <button type="submit" class="btn btn-primary">
-                                <i class="fas fa-save me-2"></i>Save Entry
-                            </button>
+                            <div class="btn-group" role="group">
+                                <button type="submit" class="btn btn-primary">
+                                    <i class="fas fa-save me-2"></i>Save Entry
+                                </button>
+                                <button type="reset" class="btn btn-outline-primary">
+                                    <i class="fas fa-broom me-2"></i>Clear
+                                </button>
+                            </div>
                         </div>
                     </form>
                 </div>
@@ -135,9 +145,9 @@
 
         <div class="col-lg-4">
             <div class="card shadow-sm border-0">
-                <div class="card-header py-3 bg-light">
-                    <h6 class="m-0 font-weight-bold text-primary">
-                        <i class="fas fa-lightbulb me-2"></i>Quick Tips
+                <div class="card-header">
+                    <h6 class="m-0">
+                        <i class="fas fa-lightbulb me-2 text-warning"></i>Quick Tips
                     </h6>
                 </div>
                 <div class="card-body">
@@ -169,6 +179,10 @@
 </div>
 
 <style>
+.form-floating > label {
+    background-color: transparent;
+    color: var(--text-secondary);
+}
 .form-floating > .form-control:focus ~ label,
 .form-floating > .form-control:not(:placeholder-shown) ~ label,
 .form-floating > .form-select:focus ~ label,
@@ -182,6 +196,20 @@
 }
 
 .tip-icon { font-size: 18px; }
+
+/* Match invoices page look-and-feel */
+.card-header {
+    border-bottom: 1px solid var(--border-color);
+}
+.card.shadow-sm {
+    border: 1px solid var(--border-color);
+}
+.btn-outline-primary {
+    border-width: 2px;
+}
+.btn-outline-primary:hover {
+    color: #fff;
+}
 </style>
 
 <script>


### PR DESCRIPTION
Make user dropdown fully dark; fix hover/divider; remove white overlay Mobile dropdown respects dark vars; improve navbar-collapse bg/z-index Improve action button grouping/contrast across pages Add dark-mode variants for badges, lists, pagination, utilities Refresh Log Time page: card header, mini-cards for Start/End, unified labels Group Save/Clear actions; Back remains secondary
Per-user theme preference: model column + migration (003) + POST /auth/profile/theme Base loads user theme (fallback to local/system); remove admin theme selector