### PR TITLE
feat(tasks): add overdue filter; fix(ui): solid light-mode dropdown/n…

### DIFF
--- a/app/static/base.css
+++ b/app/static/base.css
@@ -23,6 +23,8 @@
     --card-spacing: 1.5rem;
     --mobile-section-spacing: 1.5rem;
     --mobile-card-spacing: 1rem;
+    /* Bootstrap interop (light theme fallback) */
+    --bs-body-bg: #ffffff;
 }
 
 /* Dark theme variables */
@@ -597,8 +599,10 @@ main {
 
 /* Enhanced Navigation Layout */
 .navbar {
-    background: white !important;
-    backdrop-filter: blur(10px);
+    background: #ffffff !important;
+    background-color: #ffffff !important; /* ensure solid fill */
+    -webkit-backdrop-filter: none !important;
+    backdrop-filter: none !important; /* avoid translucency */
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
     border-bottom: 1px solid var(--border-color);
     padding: 1rem 0;
@@ -610,6 +614,13 @@ main {
 [data-theme="dark"] .navbar {
     background: #0b1220 !important;
     border-bottom-color: var(--border-color);
+}
+[data-theme="light"] .navbar,
+html[data-theme="light"] .navbar {
+    background: #ffffff !important;
+    background-color: #ffffff !important;
+    -webkit-backdrop-filter: none !important;
+    backdrop-filter: none !important;
 }
 [data-theme="dark"] .navbar-collapse {
     background: #0b1220 !important;
@@ -920,6 +931,36 @@ h6 { font-size: 1rem; }
 }
 [data-theme="dark"] .dropdown-item { color: var(--text-secondary) !important; }
 [data-theme="dark"] .dropdown-item:hover { background-color: #111827 !important; color: var(--text-primary) !important; }
+
+/* Light mode dropdown fixes (ensure solid background and proper contrast) */
+[data-theme="light"] .dropdown-menu,
+.navbar .dropdown-menu {
+    --bs-dropdown-bg: #ffffff;
+    --bs-dropdown-link-color: var(--text-primary);
+    --bs-dropdown-link-hover-bg: var(--light-color);
+    --bs-dropdown-link-hover-color: var(--text-primary);
+    --bs-dropdown-border-color: var(--border-color);
+    background-color: #ffffff !important;
+    border: 1px solid var(--border-color);
+    box-shadow: var(--card-shadow-hover);
+}
+
+[data-theme="light"] .dropdown-item,
+.navbar .dropdown-item {
+    color: var(--text-primary) !important;
+}
+
+[data-theme="light"] .dropdown-item:hover,
+.navbar .dropdown-item:hover {
+    background-color: var(--light-color) !important;
+    color: var(--text-primary) !important;
+}
+
+[data-theme="light"] .dropdown-divider,
+.navbar .dropdown-divider {
+    background-color: var(--border-color) !important;
+    opacity: 1;
+}
 
 /* Ensure dropdowns inside cards stack above adjacent content */
 .card .dropdown,

--- a/app/static/mobile.css
+++ b/app/static/mobile.css
@@ -234,7 +234,10 @@
     .navbar {
         min-height: var(--mobile-nav-height);
         padding: 0.75rem 0;
-        background: white !important;
+        background: #ffffff !important;
+        background-color: #ffffff !important;
+        -webkit-backdrop-filter: none !important;
+        backdrop-filter: none !important;
         box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
     }
     
@@ -257,7 +260,7 @@
     }
     
     .navbar-collapse {
-        background: var(--bs-body-bg);
+        background: var(--bs-body-bg, #ffffff);
         border-top: 1px solid var(--border-color);
         margin-top: 0.75rem;
         padding: 1rem 0;
@@ -302,7 +305,7 @@
         float: none;
         width: 100%;
         margin: 0;
-        border: 2px solid var(--primary-color) !important;
+        border: 1px solid var(--border-color) !important;
         box-shadow: 0 8px 25px rgba(0, 0, 0, 0.25) !important;
         background: var(--bs-dropdown-bg, #ffffff) !important;
         background-color: var(--bs-dropdown-bg, #ffffff) !important; /* ensure solid bg */
@@ -406,7 +409,7 @@
         display: block !important;
         transform: none !important;
         background: var(--bs-dropdown-bg, #ffffff) !important;
-        border: 2px solid var(--primary-color) !important;
+        border: 1px solid var(--border-color) !important;
         box-shadow: 0 8px 25px rgba(0, 0, 0, 0.25) !important;
     }
     
@@ -416,7 +419,7 @@
     .navbar .dropdown-menu[data-bs-popper="static"] {
         display: block !important;
         background: var(--bs-dropdown-bg, #ffffff) !important;
-        border: 2px solid var(--primary-color) !important;
+        border: 1px solid var(--border-color) !important;
         box-shadow: 0 8px 25px rgba(0, 0, 0, 0.25) !important;
         z-index: 9999 !important;
     }

--- a/app/templates/tasks/list.html
+++ b/app/templates/tasks/list.html
@@ -150,6 +150,14 @@
                         {% endfor %}
                     </select>
                 </div>
+                <div class="col-md-2 col-sm-6 d-flex align-items-end">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" value="1" id="overdue" name="overdue" {% if overdue %}checked{% endif %}>
+                        <label class="form-check-label" for="overdue">
+                            Show overdue only
+                        </label>
+                    </div>
+                </div>
                 <div class="col-12">
                     <div class="d-flex gap-2">
                         <button type="submit" class="btn btn-primary">

--- a/app/templates/tasks/my_tasks.html
+++ b/app/templates/tasks/my_tasks.html
@@ -147,6 +147,14 @@
                         <option value="created" {% if task_type == 'created' %}selected{% endif %}>Created by Me</option>
                     </select>
                 </div>
+                <div class="col-md-2 col-sm-6 d-flex align-items-end">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" value="1" id="overdue" name="overdue" {% if overdue %}checked{% endif %}>
+                        <label class="form-check-label" for="overdue">
+                            Show overdue only
+                        </label>
+                    </div>
+                </div>
                 <div class="col-12">
                     <div class="d-flex gap-2">
                         <button type="submit" class="btn btn-primary">


### PR DESCRIPTION
…avbar

- Backend:
  - Accept `overdue` query param in `tasks.list_tasks` and `tasks.my_tasks`
  - Filter tasks where `due_date < today` and status in ['todo','in_progress','review']
  - Use local date via `now_in_app_timezone().date()` to respect app timezone

- UI:
  - Add “Show overdue only” checkbox to `tasks/list.html` and `tasks/my_tasks.html`
  - Preserve checkbox state via template context

- Styles:
  - Enforce opaque white backgrounds for light-mode navbar and mobile navbar
  - Disable backdrop blur to prevent bleed-through
  - Normalize light-mode dropdown menu colors/borders for readability
  - Add light-theme fallback for `--bs-body-bg`
  - Tweak mobile navbar dropdown borders/shadows

Files:
- app/routes/tasks.py
- app/templates/tasks/list.html
- app/templates/tasks/my_tasks.html
- app/static/base.css
- app/static/mobile.css

Testing:
- Tasks and My Tasks: check “Show overdue only” → only overdue, non-completed/non-cancelled tasks appear
- Light mode: navbar and dropdowns show solid white backgrounds with clear borders/hover states
- Mobile: collapsed navbar menu is full-width, opaque, readable