### PR TITLE
feat(tasks): allow reopening completed tasks and improve status handling

### DIFF
--- a/app/templates/tasks/view.html
+++ b/app/templates/tasks/view.html
@@ -333,6 +333,10 @@
                         <button class="btn btn-warning btn-sm" onclick="updateTaskStatus('in_progress')">
                             <i class="fas fa-undo me-2"></i>Back to Progress
                         </button>
+                        {% elif task.status == 'done' %}
+                        <button class="btn btn-warning btn-sm" onclick="updateTaskStatus('todo')">
+                            <i class="fas fa-undo me-2"></i>Reopen Task
+                        </button>
                         {% endif %}
                         
                         {% if task.status != 'done' and task.status != 'cancelled' %}


### PR DESCRIPTION
- Enable changing status from done back to todo/in_progress/review via edit form and status endpoints
- Clear completed_at when reopening; set/preserve started_at appropriately for in_progress
- Use localized timestamps via now_in_app_timezone() for updates [[memory:7499916]]
- Add “Reopen Task” quick action in task view for done tasks
- Update flash messages; no linter issues

Files:
- app/routes/tasks.py
- app/templates/tasks/view.html