### PR TITLE
fix(kanban): replace placeholder avatars with actual user profile pic…

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -13,10 +13,10 @@
     to prevent it from being recorded in session replays.
     
     Examples:
-    - Project names: <span class="ph-no-capture">{{ project.name }}</span>
-    - Client names: <div class="ph-no-capture">{{ client.name }}</div>
+    - Project names: <span class="ph-no-capture">Project ABC</span>
+    - Client names: <div class="ph-no-capture">Client XYZ</div>
     - Time entry notes: <textarea class="ph-no-capture" name="notes"></textarea>
-    - User emails: <span class="ph-no-capture">{{ user.email }}</span>
+    - User emails: <span class="ph-no-capture">user@example.com</span>
     
     PostHog will mask these elements automatically in recordings.
     For more details, see: POSTHOG_SESSION_REPLAY_PRIVACY.md

--- a/app/templates/projects/_kanban_tailwind.html
+++ b/app/templates/projects/_kanban_tailwind.html
@@ -55,7 +55,16 @@
                         
                         <div class="mt-4 flex justify-between items-center">
                             {% if task.assigned_user %}
-                            <img src="https://i.pravatar.cc/40?u={{ task.assigned_user.id }}" alt="{{ task.assigned_user.display_name }}" class="w-8 h-8 rounded-full" title="{{ task.assigned_user.display_name }}">
+                                {% if task.assigned_user.get_avatar_url() %}
+                                    <img src="{{ task.assigned_user.get_avatar_url() }}" alt="{{ task.assigned_user.display_name }}" class="w-8 h-8 rounded-full object-cover border-2 border-primary" title="{{ task.assigned_user.display_name }}" onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
+                                    <div class="w-8 h-8 rounded-full bg-primary text-white flex items-center justify-center font-semibold text-sm" style="display: none;" title="{{ task.assigned_user.display_name }}">
+                                        {{ task.assigned_user.display_name[0:1].upper() }}
+                                    </div>
+                                {% else %}
+                                    <div class="w-8 h-8 rounded-full bg-primary text-white flex items-center justify-center font-semibold text-sm" title="{{ task.assigned_user.display_name }}">
+                                        {{ task.assigned_user.display_name[0:1].upper() }}
+                                    </div>
+                                {% endif %}
                             {% else %}
                             <div class="w-8"></div> <!-- Placeholder for alignment -->
                             {% endif %}


### PR DESCRIPTION
…tures

Replace the external placeholder avatar service (pravatar.cc) with real user avatars in the kanban board cards. This ensures consistency with the rest of the application and displays actual user profile pictures.

Changes:
- Use task.assigned_user.get_avatar_url() to fetch real user avatars
- Add graceful fallback to user initials when avatar is missing or fails to load
- Include error handling with onerror event for broken image links
- Apply consistent styling (rounded, bordered, object-cover) matching the navigation bar and profile pages
- Maintain tooltip with user display name for accessibility

This aligns the kanban board with the avatar display pattern used throughout the application and improves the user experience by showing real profile pictures instead of generic placeholder images.