### PR TITLE
feat: Add support for multiple PDF template page sizes

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -33,6 +33,7 @@ from .api_token import ApiToken
 from .calendar_event import CalendarEvent
 from .budget_alert import BudgetAlert
 from .import_export import DataImport, DataExport
+from .invoice_pdf_template import InvoicePDFTemplate
 
 __all__ = [
     "User",
@@ -73,4 +74,5 @@ __all__ = [
     "BudgetAlert",
     "DataImport",
     "DataExport",
+    "InvoicePDFTemplate",
 ]

--- a/app/models/invoice_pdf_template.py
+++ b/app/models/invoice_pdf_template.py
@@ -1,0 +1,114 @@
+"""Invoice PDF Template Model
+
+Stores PDF templates for different page sizes (A4, Letter, A3, etc.)
+"""
+from datetime import datetime
+from app import db
+
+
+class InvoicePDFTemplate(db.Model):
+    """Model for storing invoice PDF templates by page size"""
+    
+    __tablename__ = 'invoice_pdf_templates'
+    
+    id = db.Column(db.Integer, primary_key=True)
+    page_size = db.Column(db.String(20), nullable=False, unique=True)  # A4, Letter, A3, Legal, A5, etc.
+    template_html = db.Column(db.Text, nullable=True)
+    template_css = db.Column(db.Text, nullable=True)
+    design_json = db.Column(db.Text, nullable=True)  # Konva.js design state
+    is_default = db.Column(db.Boolean, default=False, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+    
+    # Standard page sizes and their dimensions in mm (for reference)
+    PAGE_SIZES = {
+        'A4': {'width': 210, 'height': 297},
+        'Letter': {'width': 216, 'height': 279},
+        'Legal': {'width': 216, 'height': 356},
+        'A3': {'width': 297, 'height': 420},
+        'A5': {'width': 148, 'height': 210},
+        'Tabloid': {'width': 279, 'height': 432},
+    }
+    
+    def __repr__(self):
+        return f'<InvoicePDFTemplate {self.page_size}>'
+    
+    @classmethod
+    def get_template(cls, page_size='A4'):
+        """Get template for a specific page size, create default if doesn't exist"""
+        template = cls.query.filter_by(page_size=page_size).first()
+        if not template:
+            # Create default template for this size
+            template = cls(
+                page_size=page_size,
+                template_html='',
+                template_css='',
+                design_json='',
+                is_default=True
+            )
+            db.session.add(template)
+            try:
+                db.session.commit()
+            except Exception:
+                db.session.rollback()
+                # Try to get again in case it was created concurrently
+                template = cls.query.filter_by(page_size=page_size).first()
+                if not template:
+                    raise
+        return template
+    
+    @classmethod
+    def get_all_templates(cls):
+        """Get all templates ordered by page size"""
+        return cls.query.order_by(cls.page_size).all()
+    
+    @classmethod
+    def get_default_template(cls):
+        """Get the default template (A4)"""
+        return cls.get_template('A4')
+    
+    @classmethod
+    def ensure_default_templates(cls):
+        """Ensure all default templates exist"""
+        default_sizes = ['A4', 'Letter', 'Legal', 'A3', 'A5']
+        for size in default_sizes:
+            template = cls.query.filter_by(page_size=size).first()
+            if not template:
+                template = cls(
+                    page_size=size,
+                    template_html='',
+                    template_css='',
+                    design_json='',
+                    is_default=True
+                )
+                db.session.add(template)
+        try:
+            db.session.commit()
+        except Exception:
+            db.session.rollback()
+    
+    def to_dict(self):
+        """Convert template to dictionary"""
+        return {
+            'id': self.id,
+            'page_size': self.page_size,
+            'template_html': self.template_html or '',
+            'template_css': self.template_css or '',
+            'design_json': self.design_json or '',
+            'is_default': self.is_default,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None
+        }
+    
+    def get_page_dimensions_mm(self):
+        """Get page dimensions in mm"""
+        return self.PAGE_SIZES.get(self.page_size, {'width': 210, 'height': 297})
+    
+    def get_page_dimensions_px(self, dpi=72):
+        """Get page dimensions in pixels at given DPI"""
+        dims_mm = self.get_page_dimensions_mm()
+        # Convert mm to pixels: 1 mm = (dpi / 25.4) pixels
+        width_px = int((dims_mm['width'] / 25.4) * dpi)
+        height_px = int((dims_mm['height'] / 25.4) * dpi)
+        return {'width': width_px, 'height': height_px}
+

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -390,27 +390,55 @@ def settings():
 @login_required
 @admin_or_permission_required('manage_settings')
 def pdf_layout():
-    """Edit PDF invoice layout template (HTML and CSS)."""
-    settings_obj = Settings.get_settings()
+    """Edit PDF invoice layout template (HTML and CSS) by page size."""
+    from app.models import InvoicePDFTemplate
+    
+    # Get page size from query parameter or form, default to A4
+    page_size = request.args.get('size', request.form.get('page_size', 'A4'))
+    
+    # Ensure valid page size
+    valid_sizes = ['A4', 'Letter', 'Legal', 'A3', 'A5', 'Tabloid']
+    if page_size not in valid_sizes:
+        page_size = 'A4'
+    
+    # Get or create template for this page size
+    template = InvoicePDFTemplate.get_template(page_size)
+    
     if request.method == 'POST':
         html_template = request.form.get('invoice_pdf_template_html', '')
         css_template = request.form.get('invoice_pdf_template_css', '')
         design_json = request.form.get('design_json', '')
         
-        settings_obj.invoice_pdf_template_html = html_template
-        settings_obj.invoice_pdf_template_css = css_template
-        settings_obj.invoice_pdf_design_json = design_json
+        # Update template
+        template.template_html = html_template
+        template.template_css = css_template
+        template.design_json = design_json
+        template.updated_at = datetime.utcnow()
+        
         if not safe_commit('admin_update_pdf_layout'):
             from flask_babel import gettext as _
             flash(_('Could not update PDF layout due to a database error.'), 'error')
         else:
             from flask_babel import gettext as _
             flash(_('PDF layout updated successfully'), 'success')
-        return redirect(url_for('admin.pdf_layout'))
+        return redirect(url_for('admin.pdf_layout', size=page_size))
+    
+    # Get all templates for dropdown
+    all_templates = InvoicePDFTemplate.get_all_templates()
+    
     # Provide initial defaults to the template if no custom HTML/CSS saved
-    initial_html = settings_obj.invoice_pdf_template_html or ''
-    initial_css = settings_obj.invoice_pdf_template_css or ''
-    design_json = settings_obj.invoice_pdf_design_json or ''
+    initial_html = template.template_html or ''
+    initial_css = template.template_css or ''
+    design_json = template.design_json or ''
+    
+    # Fallback to legacy Settings if template is empty
+    if not initial_html and not initial_css:
+        settings_obj = Settings.get_settings()
+        initial_html = settings_obj.invoice_pdf_template_html or ''
+        initial_css = settings_obj.invoice_pdf_template_css or ''
+        design_json = settings_obj.invoice_pdf_design_json or ''
+    
+    # Load default template if still empty
     try:
         if not initial_html:
             env = current_app.jinja_env
@@ -428,7 +456,14 @@ def pdf_layout():
             initial_css = css_src
     except Exception:
         pass
-    return render_template('admin/pdf_layout.html', settings=settings_obj, initial_html=initial_html, initial_css=initial_css, design_json=design_json)
+    
+    return render_template('admin/pdf_layout.html', 
+                         settings=Settings.get_settings(), 
+                         initial_html=initial_html, 
+                         initial_css=initial_css, 
+                         design_json=design_json,
+                         page_size=page_size,
+                         all_templates=all_templates)
 
 
 @admin_bp.route('/admin/pdf-layout/reset', methods=['POST'])

--- a/app/templates/invoices/view.html
+++ b/app/templates/invoices/view.html
@@ -3,14 +3,42 @@
 {% block content %}
 <div class="flex justify-between items-center mb-6">
     <h1 class="text-2xl font-bold">Invoice {{ invoice.invoice_number }}</h1>
-    <div class="flex gap-2">
+    <div class="flex gap-2 items-center">
         <a href="{{ url_for('invoices.edit_invoice', invoice_id=invoice.id) }}" class="bg-primary text-white px-4 py-2 rounded-lg hover:bg-primary-dark">Edit</a>
-        <a href="{{ url_for('invoices.export_invoice_pdf', invoice_id=invoice.id) }}" class="bg-secondary text-white px-4 py-2 rounded-lg hover:bg-secondary-dark">Export PDF</a>
+        <div class="flex gap-2 items-center">
+            <select id="pdf-size-selector" class="bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm font-medium hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
+                <option value="A4">A4</option>
+                <option value="Letter">Letter</option>
+                <option value="Legal">Legal</option>
+                <option value="A3">A3</option>
+                <option value="A5">A5</option>
+                <option value="Tabloid">Tabloid</option>
+            </select>
+            <a id="export-pdf-link" href="{{ url_for('invoices.export_invoice_pdf', invoice_id=invoice.id) }}" class="bg-secondary text-white px-4 py-2 rounded-lg hover:bg-secondary-dark">Export PDF</a>
+        </div>
         <a href="{{ url_for('payments.create_payment', invoice_id=invoice.id) }}" class="bg-green-500 text-white px-4 py-2 rounded-lg hover:bg-green-600">Record Payment</a>
         <button type="button" onclick="showDeleteModal('{{ invoice.id }}', '{{ invoice.invoice_number }}')" class="bg-red-500 text-white px-4 py-2 rounded-lg hover:bg-red-600">
             <i class="fas fa-trash mr-1"></i>Delete
         </button>
     </div>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const sizeSelector = document.getElementById('pdf-size-selector');
+            const exportLink = document.getElementById('export-pdf-link');
+            if (sizeSelector && exportLink) {
+                // Initialize export link with default size (A4)
+                const defaultSize = sizeSelector.value || 'A4';
+                const baseUrl = "{{ url_for('invoices.export_invoice_pdf', invoice_id=invoice.id) }}";
+                exportLink.href = baseUrl + '?size=' + defaultSize;
+                
+                // Update export link when size changes
+                sizeSelector.addEventListener('change', function() {
+                    const size = this.value;
+                    exportLink.href = baseUrl + '?size=' + size;
+                });
+            }
+        });
+    </script>
 </div>
 
 <div class="bg-card-light dark:bg-card-dark p-6 rounded-lg shadow">

--- a/app/utils/pdf_generator.py
+++ b/app/utils/pdf_generator.py
@@ -8,7 +8,8 @@ import html as html_lib
 from datetime import datetime
 from weasyprint import HTML, CSS
 from weasyprint.text.fonts import FontConfiguration
-from app.models import Settings
+from app.models import Settings, InvoicePDFTemplate
+from app import db
 from flask import current_app
 from flask_babel import gettext as _
 try:
@@ -21,19 +22,97 @@ from flask import render_template
 class InvoicePDFGenerator:
     """Generate PDF invoices with company branding"""
     
-    def __init__(self, invoice, settings=None):
+    def __init__(self, invoice, settings=None, page_size='A4'):
         self.invoice = invoice
         self.settings = settings or Settings.get_settings()
+        self.page_size = page_size or 'A4'
     
     def generate_pdf(self):
         """Generate PDF content and return as bytes"""
-        use_custom_html = bool((self.settings.invoice_pdf_template_html or '').strip())
-        use_custom_css = bool((self.settings.invoice_pdf_template_css or '').strip())
-        if use_custom_html or use_custom_css:
-            html_content, css_content = self._render_from_custom_template()
+        # Enable debugging - output directly to stdout for Docker console visibility
+        import sys
+        
+        # Force unbuffered output to stdout - this ensures Docker sees it immediately
+        def debug_print(msg):
+            """Print debug message to stdout with immediate flush for Docker visibility"""
+            print(msg, file=sys.stdout, flush=True)
+            # Also try stderr
+            print(msg, file=sys.stderr, flush=True)
+        
+        # Header - make it very visible
+        print("\n" + "="*80, file=sys.stdout, flush=True)
+        print("PDF GENERATOR generate_pdf() CALLED", file=sys.stdout, flush=True)
+        print("="*80, file=sys.stdout, flush=True)
+        debug_print(f"\nPDF GENERATOR DEBUG - Page Size: {self.page_size}")
+        debug_print(f"{'='*80}\n")
+        
+        # Get template for the specified page size
+        # Refresh the template from DB to ensure we have the latest version
+        from app.models import InvoicePDFTemplate
+        db.session.expire_all()  # Clear any cached data
+        template = InvoicePDFTemplate.query.filter_by(page_size=self.page_size).first()
+        if not template:
+            template = InvoicePDFTemplate.get_template(self.page_size)
+        
+        debug_print(f"[DEBUG] Retrieved template: page_size={template.page_size}, id={template.id}")
+        
+        # Verify we got the correct template
+        if template.page_size != self.page_size:
+            debug_print(f"[WARNING] Template page_size mismatch! Expected {self.page_size}, got {template.page_size}")
+            # This should never happen, but handle it just in case
+            template = InvoicePDFTemplate.query.filter_by(page_size=self.page_size).first()
+            if not template:
+                template = InvoicePDFTemplate.get_template(self.page_size)
+        
+        # Check if this size-specific template has content
+        # Use raw content - preserve exact content as saved
+        template_html = template.template_html or ''
+        template_css = template.template_css or ''
+        
+        debug_print(f"[DEBUG] Template content - HTML length={len(template_html)}, CSS length={len(template_css)}")
+        
+        if template_html:
+            html_preview = template_html[:200].replace('\n', '\\n')
+            debug_print(f"[DEBUG] Template HTML preview (first 200 chars): {html_preview}")
+        
+        if template_css:
+            css_preview = template_css[:200].replace('\n', '\\n')
+            debug_print(f"[DEBUG] Template CSS preview (first 200 chars): {css_preview}")
+            
+            # Check for @page rules in CSS
+            import re
+            page_rules = re.findall(r'@page\s*\{[^}]*\}', template_css, re.IGNORECASE | re.DOTALL)
+            if page_rules:
+                debug_print(f"[DEBUG] Found {len(page_rules)} @page rule(s) in template CSS:")
+                for i, rule in enumerate(page_rules):
+                    debug_print(f"[DEBUG]   @page rule {i+1}: {rule[:100]}")
+        
+        # Check if template has meaningful content (not just whitespace)
+        has_custom_template = bool(template_html.strip() or template_css.strip())
+        
+        # Only use this template if it has content for this specific size
+        if has_custom_template:
+            debug_print(f"[DEBUG] Using custom template for page size {self.page_size}")
+            # Use the template for this specific page size
+            html_content, css_content = self._render_from_custom_template(template)
         else:
-            html_content = self._generate_html()
-            css_content = self._generate_css()
+            # No template for this size - check if there's a legacy Settings template
+            # This matches the editor's fallback behavior
+            settings_html = (self.settings.invoice_pdf_template_html or '').strip()
+            settings_css = (self.settings.invoice_pdf_template_css or '').strip()
+            
+            if settings_html or settings_css:
+                # Use legacy Settings template, but ensure page size is correct
+                from types import SimpleNamespace
+                legacy_template = SimpleNamespace()
+                legacy_template.page_size = self.page_size
+                legacy_template.template_html = settings_html
+                legacy_template.template_css = settings_css
+                html_content, css_content = self._render_from_custom_template(legacy_template)
+            else:
+                # No templates at all, use default generation
+                html_content = self._generate_html()
+                css_content = self._generate_css()
         
         # Configure fonts
         font_config = FontConfiguration()
@@ -44,24 +123,270 @@ class InvoicePDFGenerator:
             base_url = current_app.root_path
         except Exception:
             base_url = None
+        # Final verification: ensure CSS has correct @page size using the same logic as update_page_size_in_css
+        # This is critical - WeasyPrint uses @page rules from stylesheets
+        import re
+        debug_print("[DEBUG] Final CSS verification - checking @page rules")
+        
+        # Check what @page size is in CSS before update
+        if '@page' in css_content:
+            page_size_match = re.search(r'@page\s*\{[^}]*?size\s*:\s*([^;}\n]+)', css_content, re.IGNORECASE | re.DOTALL)
+            if page_size_match:
+                found_size = page_size_match.group(1).strip()
+                debug_print(f"[DEBUG] Found @page size in CSS: '{found_size}' (expected: '{self.page_size}')")
+            else:
+                debug_print("[DEBUG] @page rule exists but no size property found")
+        
+        # Re-apply update_page_size_in_css to ensure correctness (this handles nested braces properly)
+        if '@page' in css_content:
+            # Use the same function that's defined in _render_from_custom_template
+            # But we need to call it here, so define a helper
+            def final_update_page_size(css_text):
+                """Final update of @page size - same logic as update_page_size_in_css"""
+                page_match = re.search(r'@page\s*\{', css_text, re.IGNORECASE | re.MULTILINE)
+                if page_match:
+                    start_pos = page_match.start()
+                    brace_count = 0
+                    end_pos = len(css_text)
+                    for i in range(page_match.end() - 1, len(css_text)):
+                        if css_text[i] == '{':
+                            brace_count += 1
+                        elif css_text[i] == '}':
+                            brace_count -= 1
+                            if brace_count == 0:
+                                end_pos = i + 1
+                                break
+                    page_block = css_text[start_pos:end_pos]
+                    if re.search(r'size\s*:', page_block, re.IGNORECASE):
+                        updated_block = re.sub(
+                            r'size\s*:\s*[^;}\n]+',
+                            f'size: {self.page_size};',
+                            page_block,
+                            flags=re.IGNORECASE | re.MULTILINE
+                        )
+                        css_text = css_text[:start_pos] + updated_block + css_text[end_pos:]
+                        debug_print("[DEBUG] Updated @page size in CSS block")
+                return css_text
+            css_content = final_update_page_size(css_content)
+            
+            # Verify after update
+            page_size_match_after = re.search(r'@page\s*\{[^}]*?size\s*:\s*([^;}\n]+)', css_content, re.IGNORECASE | re.DOTALL)
+            if page_size_match_after:
+                found_size_after = page_size_match_after.group(1).strip()
+                debug_print(f"[DEBUG] After update - @page size in CSS: '{found_size_after}'")
+                if found_size_after != self.page_size:
+                    debug_print(f"[ERROR] @page size still incorrect! Expected '{self.page_size}', found '{found_size_after}'")
+                else:
+                    debug_print(f"[DEBUG] ✓ @page size is correct: '{found_size_after}'")
+        
+        debug_print(f"[DEBUG] Generating PDF with WeasyPrint")
+        debug_print(f"[DEBUG]   - HTML length: {len(html_content)}")
+        debug_print(f"[DEBUG]   - CSS length: {len(css_content)}")
+        
+        # Log final CSS @page rule that will be used
+        if '@page' in css_content:
+            page_rule_match = re.search(r'(@page\s*\{[^}]*\})', css_content, re.IGNORECASE | re.DOTALL)
+            if page_rule_match:
+                final_page_rule = page_rule_match.group(1)[:150]  # First 150 chars
+                debug_print(f"[DEBUG] Final @page rule being used: {final_page_rule}")
+        
         html_doc = HTML(string=html_content, base_url=base_url)
         css_doc = CSS(string=css_content, font_config=font_config)
         pdf_bytes = html_doc.write_pdf(stylesheets=[css_doc], font_config=font_config)
         
+        debug_print(f"[DEBUG] PDF generated successfully - size: {len(pdf_bytes)} bytes")
+        debug_print(f"{'='*80}\n")
+        
         return pdf_bytes
-    def _render_from_custom_template(self):
-        """Render HTML and CSS from custom templates stored in settings, with fallback to default template."""
-        html_template = (self.settings.invoice_pdf_template_html or '').strip()
-        css_template = (self.settings.invoice_pdf_template_css or '').strip()
-        html = ''
-        if css_template:
-            css = css_template
+    def _render_from_custom_template(self, template=None):
+        """Render HTML and CSS from custom templates stored in database, with fallback to default template."""
+        # Define debug_print for this method scope
+        import sys
+        def debug_print(msg):
+            """Print debug message to stdout with immediate flush for Docker visibility"""
+            print(msg, file=sys.stdout, flush=True)
+            print(msg, file=sys.stderr, flush=True)
+        
+        if template:
+            # Ensure template matches the selected page size
+            if hasattr(template, 'page_size') and template.page_size != self.page_size:
+                # Template doesn't match - this shouldn't happen, but handle it
+                # Get the correct template
+                from app.models import InvoicePDFTemplate
+                correct_template = InvoicePDFTemplate.query.filter_by(page_size=self.page_size).first()
+                if correct_template:
+                    template = correct_template
+                else:
+                    # Couldn't find correct template - use default generation instead
+                    raise ValueError(f"Template for page size {self.page_size} not found")
+            
+            # Don't strip - preserve exact content as saved (whitespace might be important)
+            html_template = template.template_html or ''
+            css_template = template.template_css or ''
         else:
+            # No template provided - this should not happen in normal flow
+            # If it does, we can't proceed without a template
+            raise ValueError(f"No template provided for page size {self.page_size}. This is a bug.")
+        html = ''
+        def update_page_size_in_css(css_text):
+            """Update @page size property to match selected page size"""
+            import re
+            # Find @page rule and update its size property
+            # Handle nested @bottom-center rules by finding matching braces
+            page_match = re.search(r'@page\s*\{', css_text, re.IGNORECASE | re.MULTILINE)
+            if page_match:
+                start_pos = page_match.start()
+                # Find matching closing brace, accounting for nested braces
+                brace_count = 0
+                pos = page_match.end() - 1
+                end_pos = len(css_text)
+                for i in range(page_match.end() - 1, len(css_text)):
+                    if css_text[i] == '{':
+                        brace_count += 1
+                    elif css_text[i] == '}':
+                        brace_count -= 1
+                        if brace_count == 0:
+                            end_pos = i + 1
+                            break
+                
+                page_block = css_text[start_pos:end_pos]
+                
+                # Replace or add size property
+                if re.search(r'size\s*:', page_block, re.IGNORECASE):
+                    # Replace existing size property - handle any whitespace and values
+                    # Match: size: A4; or size: A4 ; or size:Letter; etc.
+                    # Use a more robust pattern that handles various formats
+                    updated_block = re.sub(
+                        r'size\s*:\s*[^;}\n]+',
+                        f'size: {self.page_size}',
+                        page_block,
+                        flags=re.IGNORECASE | re.MULTILINE
+                    )
+                    css_text = css_text[:start_pos] + updated_block + css_text[end_pos:]
+                else:
+                    # Add size property after @page {
+                    updated_block = re.sub(
+                        r'(@page\s*\{)',
+                        r'\1\n            size: ' + self.page_size + r';',
+                        page_block,
+                        count=1,
+                        flags=re.IGNORECASE
+                    )
+                    css_text = css_text[:start_pos] + updated_block + css_text[end_pos:]
+            else:
+                # Add @page rule at the beginning if it doesn't exist
+                new_page_rule = f'@page {{\n            size: {self.page_size};\n            margin: 2cm;\n        }}\n\n'
+                css_text = new_page_rule + css_text
+            
+            return css_text
+        
+        def update_page_size_in_html(html_text):
+            """Update @page size property in HTML's inline <style> tags"""
+            import re
+            # Find and update @page rules in <style> tags
+            def update_style_tag(match):
+                style_content = match.group(2)  # Content inside <style> tag
+                updated_content = update_page_size_in_css(style_content)
+                return f'{match.group(1)}{updated_content}{match.group(3)}'
+            
+            # Match <style> tags (with or without attributes)
+            style_pattern = r'(<style[^>]*>)(.*?)(</style>)'
+            if re.search(style_pattern, html_text, re.IGNORECASE | re.DOTALL):
+                html_text = re.sub(style_pattern, update_style_tag, html_text, flags=re.IGNORECASE | re.DOTALL)
+            
+            return html_text
+        
+        def remove_page_rule_from_html(html_text):
+            """Remove @page rules from HTML inline styles to avoid conflicts with separate CSS"""
+            import re
+            def remove_from_style_tag(match):
+                style_content = match.group(2)
+                # Remove @page rule from style content
+                # Need to handle nested @bottom-center rules properly
+                # Match @page { ... } including any nested rules
+                brace_count = 0
+                page_pattern = r'@page\s*\{'
+                page_match = re.search(page_pattern, style_content, re.IGNORECASE)
+                
+                if page_match:
+                    start = page_match.start()
+                    # Find matching closing brace
+                    pos = page_match.end() - 1
+                    end = len(style_content)
+                    for i in range(page_match.end() - 1, len(style_content)):
+                        if style_content[i] == '{':
+                            brace_count += 1
+                        elif style_content[i] == '}':
+                            brace_count -= 1
+                            if brace_count == 0:
+                                end = i + 1
+                                break
+                    # Remove the @page rule
+                    style_content = style_content[:start] + style_content[end:]
+                    # Clean up any double newlines or extra whitespace
+                    style_content = re.sub(r'\n\s*\n', '\n', style_content)
+                
+                return f'{match.group(1)}{style_content}{match.group(3)}'
+            
+            # Match <style> tags and remove @page rules from them
+            style_pattern = r'(<style[^>]*>)(.*?)(</style>)'
+            if re.search(style_pattern, html_text, re.IGNORECASE | re.DOTALL):
+                html_text = re.sub(style_pattern, remove_from_style_tag, html_text, flags=re.IGNORECASE | re.DOTALL)
+            
+            return html_text
+        
+        # Handle CSS: When both HTML (with inline styles) and separate CSS exist,
+        # extract inline styles, merge with separate CSS, and remove from HTML to avoid conflicts
+        import re
+        css_to_use = ''
+        html_inline_styles_extracted = False
+        
+        # Extract inline styles from HTML if present
+        extracted_inline_css = ''
+        if html_template and '<style>' in html_template:
+            style_match = re.search(r'<style[^>]*>(.*?)</style>', html_template, re.IGNORECASE | re.DOTALL)
+            if style_match:
+                extracted_inline_css = style_match.group(1)
+                html_inline_styles_extracted = True
+        
+        if css_template and css_template.strip():
+            # Use separate CSS template - this is the authoritative source
+            # Don't merge with inline styles - the CSS template should contain everything needed
+            # (Editor saves both HTML with styles AND CSS, but CSS is the clean source)
+            debug_print(f"[DEBUG] Using separate CSS template (length: {len(css_template)})")
+            
+            # Check @page size before update
+            import re
+            before_match = re.search(r'@page\s*\{[^}]*?size\s*:\s*([^;}\n]+)', css_template, re.IGNORECASE | re.DOTALL)
+            if before_match:
+                before_size = before_match.group(1).strip()
+                debug_print(f"[DEBUG] CSS template @page size BEFORE update: '{before_size}'")
+            
+            css_to_use = update_page_size_in_css(css_template)
+            
+            # Check @page size after update
+            after_match = re.search(r'@page\s*\{[^}]*?size\s*:\s*([^;}\n]+)', css_to_use, re.IGNORECASE | re.DOTALL)
+            if after_match:
+                after_size = after_match.group(1).strip()
+                debug_print(f"[DEBUG] CSS template @page size AFTER update: '{after_size}'")
+                if after_size != self.page_size:
+                    debug_print(f"[ERROR] @page size update failed! Expected '{self.page_size}', got '{after_size}'")
+                else:
+                    debug_print(f"[DEBUG] ✓ CSS template @page size correctly updated to '{after_size}'")
+        elif extracted_inline_css:
+            # Only inline styles exist - extract and use them
+            css_to_use = update_page_size_in_css(extracted_inline_css)
+        else:
+            # No CSS provided, use default
             try:
                 from flask import render_template as _render_tpl
-                css = _render_tpl('invoices/pdf_styles_default.css')
+                css_to_use = _render_tpl('invoices/pdf_styles_default.css')
+                css_to_use = update_page_size_in_css(css_to_use)
             except Exception:
-                css = self._generate_css()
+                css_to_use = self._generate_css()
+        
+        # Ensure @page rule has correct size - this is critical for PDF generation
+        css = css_to_use
         # Import helper functions for template
         from app.utils.template_filters import get_logo_base64
         from babel.dates import format_date as babel_format_date
@@ -129,7 +454,29 @@ class InvoicePDFGenerator:
             # Render using Flask's Jinja environment to include app filters and _()
             if html_template:
                 from flask import render_template_string
-                html = render_template_string(html_template, 
+                # When we have separate CSS, remove @page rules from HTML inline styles
+                # to ensure the separate CSS @page rule is used (WeasyPrint uses first @page it finds)
+                # Keep all other inline styles (like positioning) to preserve layout
+                if html_inline_styles_extracted and css_template:
+                    # Check if HTML has @page rules
+                    import re
+                    html_page_rules = re.findall(r'@page\s*\{[^}]*\}', html_template, re.IGNORECASE | re.DOTALL)
+                    if html_page_rules:
+                        debug_print(f"[DEBUG] Found {len(html_page_rules)} @page rule(s) in HTML inline styles - removing them")
+                        for i, rule in enumerate(html_page_rules):
+                            debug_print(f"[DEBUG]   HTML @page rule {i+1}: {rule[:80]}")
+                    
+                    # Remove @page rules from HTML inline styles (keep everything else)
+                    html_template_updated = remove_page_rule_from_html(html_template)
+                    debug_print("[DEBUG] Removed @page rules from HTML inline styles")
+                else:
+                    # No separate CSS or no inline styles - use template as-is or update inline @page
+                    if html_template and '<style>' in html_template:
+                        # Update @page size in HTML inline styles
+                        html_template_updated = update_page_size_in_html(html_template)
+                    else:
+                        html_template_updated = html_template
+                html = render_template_string(html_template_updated, 
                                              invoice=invoice_data,  # Use wrapped object with lists
                                              settings=self.settings, 
                                              Path=Path,
@@ -498,226 +845,229 @@ class InvoicePDFGenerator:
     
     def _generate_css(self):
         """Generate CSS styles for the invoice"""
+        # Get page size, defaulting to A4
+        page_size = self.page_size or 'A4'
+        # Use .format() instead of f-string to avoid escaping all CSS braces
         return """
-        @page {
-            size: A4;
+        @page {{
+            size: {page_size};
             margin: 2cm;
-            @bottom-center {
+            @bottom-center {{
                 content: "Page " counter(page) " of " counter(pages);
                 font-size: 10pt;
                 color: #666;
-            }
-        }
+            }}
+        }}
         
-        body {
+        body {{
             font-family: 'Helvetica Neue', Arial, sans-serif;
             font-size: 12pt;
             line-height: 1.4;
             color: #333;
             margin: 0;
             padding: 0;
-        }
+        }}
         
-        .invoice-container {
+        .invoice-container {{
             max-width: 100%;
-        }
+        }}
         
-        .header {
+        .header {{
             display: flex;
             justify-content: space-between;
             align-items: flex-start;
             margin-bottom: 2em;
             border-bottom: 2px solid #007bff;
             padding-bottom: 1em;
-        }
+        }}
         
-        .company-info {
+        .company-info {{
             flex: 1;
-        }
+        }}
         
-        .company-logo {
+        .company-logo {{
             max-width: 150px;
             max-height: 80px;
             display: block;
             margin-left: auto;
             margin-right: 0;
             margin-bottom: 1em;
-        }
+        }}
         
-        .company-name {
+        .company-name {{
             font-size: 24pt;
             font-weight: bold;
             color: #007bff;
             margin: 0 0 0.5em 0;
-        }
+        }}
         
-        .company-address {
+        .company-address {{
             margin-bottom: 0.5em;
             line-height: 1.3;
-        }
+        }}
         
-        .company-contact {
+        .company-contact {{
             margin-bottom: 0.5em;
-        }
+        }}
         
-        .company-contact span {
+        .company-contact span {{
             display: block;
             margin-bottom: 0.2em;
             font-size: 10pt;
-        }
+        }}
         
-        .company-tax {
+        .company-tax {{
             font-size: 10pt;
             color: #666;
-        }
+        }}
         
-        .invoice-info {
+        .invoice-info {{
             text-align: right;
             min-width: 200px;
-        }
+        }}
         
-        .logo-container {
+        .logo-container {{
             text-align: right;
             margin-bottom: 1em;
-        }
+        }}
         
-        .invoice-title {
+        .invoice-title {{
             font-size: 28pt;
             font-weight: bold;
             color: #007bff;
             margin: 0 0 1em 0;
-        }
+        }}
         
-        .invoice-details .detail-row {
+        .invoice-details .detail-row {{
             margin-bottom: 0.5em;
-        }
+        }}
         
-        .detail-row .label {
+        .detail-row .label {{
             font-weight: bold;
             margin-right: 0.5em;
-        }
+        }}
         
-        .status-draft { color: #6c757d; }
-        .status-sent { color: #17a2b8; }
-        .status-paid { color: #28a745; }
-        .status-overdue { color: #dc3545; }
-        .status-cancelled { color: #343a40; }
+        .status-draft {{ color: #6c757d; }}
+        .status-sent {{ color: #17a2b8; }}
+        .status-paid {{ color: #28a745; }}
+        .status-overdue {{ color: #dc3545; }}
+        .status-cancelled {{ color: #343a40; }}
         
-        .client-section, .project-section {
+        .client-section, .project-section {{
             margin-bottom: 2em;
-        }
+        }}
         
-        .client-section h3, .project-section h3 {
+        .client-section h3, .project-section h3 {{
             font-size: 14pt;
             font-weight: bold;
             color: #007bff;
             margin: 0 0 0.5em 0;
             border-bottom: 1px solid #dee2e6;
             padding-bottom: 0.3em;
-        }
+        }}
         
-        .client-name {
+        .client-name {{
             font-weight: bold;
             font-size: 14pt;
             margin-bottom: 0.5em;
-        }
+        }}
         
-        .client-email, .client-address, .project-description {
+        .client-email, .client-address, .project-description {{
             margin-bottom: 0.3em;
             color: #666;
-        }
+        }}
         
-        .items-section {
+        .items-section {{
             margin-bottom: 2em;
-        }
+        }}
         
-        .invoice-table {
+        .invoice-table {{
             width: 100%;
             border-collapse: collapse;
             margin-bottom: 1em;
-        }
+        }}
         
         .invoice-table th,
-        .invoice-table td {
+        .invoice-table td {{
             border: 1px solid #dee2e6;
             padding: 0.75em;
             text-align: left;
-        }
+        }}
         
-        .invoice-table th {
+        .invoice-table th {{
             background-color: #f8f9fa;
             font-weight: bold;
             color: #495057;
-        }
+        }}
         
-        .description { width: 40%; }
-        .quantity { width: 15%; text-align: center; }
-        .unit-price { width: 20%; text-align: right; }
-        .total { width: 25%; text-align: right; }
+        .description {{ width: 40%; }}
+        .quantity {{ width: 15%; text-align: center; }}
+        .unit-price {{ width: 20%; text-align: right; }}
+        .total {{ width: 25%; text-align: right; }}
         
-        .text-center { text-align: center; }
-        .text-right { text-align: right; }
+        .text-center {{ text-align: center; }}
+        .text-right {{ text-align: right; }}
         
-        .time-entry-info {
+        .time-entry-info {{
             color: #6c757d;
             font-style: italic;
-        }
+        }}
         
-        .subtotal { background-color: #f8f9fa; }
-        .tax { background-color: #fff3cd; }
-        .total { background-color: #d1ecf1; font-weight: bold; }
+        .subtotal {{ background-color: #f8f9fa; }}
+        .tax {{ background-color: #fff3cd; }}
+        .total {{ background-color: #d1ecf1; font-weight: bold; }}
         
-        .additional-info {
+        .additional-info {{
             margin-bottom: 2em;
-        }
+        }}
         
-        .notes-section, .terms-section {
+        .notes-section, .terms-section {{
             margin-bottom: 1em;
-        }
+        }}
         
-        .notes-section h4, .terms-section h4 {
+        .notes-section h4, .terms-section h4 {{
             font-size: 12pt;
             font-weight: bold;
             color: #495057;
             margin: 0 0 0.5em 0;
-        }
+        }}
         
-        .footer {
+        .footer {{
             margin-top: 2em;
             padding-top: 1em;
             border-top: 1px solid #dee2e6;
-        }
+        }}
         
-        .payment-info {
+        .payment-info {{
             margin-bottom: 1em;
-        }
+        }}
         
-        .payment-info h4 {
+        .payment-info h4 {{
             font-size: 12pt;
             font-weight: bold;
             color: #495057;
             margin: 0 0 0.5em 0;
-        }
+        }}
         
-        .bank-info {
+        .bank-info {{
             color: #666;
             line-height: 1.3;
-        }
+        }}
         
-        .terms h4 {
+        .terms h4 {{
             font-size: 12pt;
             font-weight: bold;
             color: #495057;
             margin: 0 0 0.5em 0;
-        }
+        }}
         
-        .terms p {
+        .terms p {{
             color: #666;
             line-height: 1.3;
-        }
+        }}
         
         /* Utility classes */
-        .nl2br {
+        .nl2br {{
             white-space: pre-line;
-        }
-        """
+        }}
+        """.format(page_size=page_size)

--- a/migrations/versions/041_add_invoice_pdf_templates_table.py
+++ b/migrations/versions/041_add_invoice_pdf_templates_table.py
@@ -1,0 +1,94 @@
+"""Add invoice_pdf_templates table for storing templates by size
+
+Revision ID: 041_add_invoice_pdf_templates
+Revises: 040_import_export
+Create Date: 2025-11-01
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from datetime import datetime
+
+
+# revision identifiers, used by Alembic.
+revision = '041_add_invoice_pdf_templates'
+down_revision = '040_import_export'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Create invoice_pdf_templates table (idempotent)"""
+    from sqlalchemy import inspect
+    
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    existing_tables = inspector.get_table_names()
+    
+    if 'invoice_pdf_templates' not in existing_tables:
+        op.create_table(
+            'invoice_pdf_templates',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('page_size', sa.String(length=20), nullable=False),  # A4, Letter, A3, Legal, etc.
+            sa.Column('template_html', sa.Text(), nullable=True),
+            sa.Column('template_css', sa.Text(), nullable=True),
+            sa.Column('design_json', sa.Text(), nullable=True),  # Konva.js design state
+            sa.Column('is_default', sa.Boolean(), nullable=False, server_default='0'),
+            sa.Column('created_at', sa.DateTime(), nullable=False, server_default=sa.func.now()),
+            sa.Column('updated_at', sa.DateTime(), nullable=False, server_default=sa.func.now(), onupdate=sa.func.now()),
+            sa.PrimaryKeyConstraint('id'),
+            sa.UniqueConstraint('page_size', name='uq_invoice_pdf_templates_page_size')
+        )
+        
+        # Create indexes for better query performance
+        with op.batch_alter_table('invoice_pdf_templates', schema=None) as batch_op:
+            batch_op.create_index('ix_invoice_pdf_templates_page_size', ['page_size'])
+            batch_op.create_index('ix_invoice_pdf_templates_is_default', ['is_default'])
+        
+        # Migrate existing template from Settings to invoice_pdf_templates
+        # Get existing template from settings table
+        result = conn.execute(sa.text("""
+            SELECT invoice_pdf_template_html, invoice_pdf_template_css, invoice_pdf_design_json
+            FROM settings
+            LIMIT 1
+        """))
+        row = result.fetchone()
+        
+        if row:
+            template_html = row[0] or ''
+            template_css = row[1] or ''
+            design_json = row[2] or ''
+        else:
+            template_html = ''
+            template_css = ''
+            design_json = ''
+        
+        # Insert A4 template (default)
+        conn.execute(sa.text("""
+            INSERT INTO invoice_pdf_templates (page_size, template_html, template_css, design_json, is_default)
+            VALUES ('A4', :html, :css, :json, TRUE)
+        """), {'html': template_html, 'css': template_css, 'json': design_json})
+        
+        # Create default templates for common sizes
+        # Check if they exist first to avoid conflicts
+        sizes = ['Letter', 'A3', 'Legal', 'A5']
+        for size in sizes:
+            # Check if template exists for this size
+            result = conn.execute(sa.text("""
+                SELECT COUNT(*) FROM invoice_pdf_templates WHERE page_size = :size
+            """), {'size': size})
+            count = result.fetchone()[0]
+            
+            if count == 0:
+                conn.execute(sa.text("""
+                    INSERT INTO invoice_pdf_templates (page_size, template_html, template_css, design_json, is_default)
+                    VALUES (:size, '', '', '', TRUE)
+                """), {'size': size})
+
+
+def downgrade():
+    """Drop invoice_pdf_templates table and optionally restore to Settings"""
+    # Optionally migrate back to Settings before dropping
+    # For now, just drop the table
+    op.drop_table('invoice_pdf_templates')
+

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='timetracker',
-    version='3.6.0',
+    version='3.7.0',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[

--- a/templates/admin/pdf_layout.html
+++ b/templates/admin/pdf_layout.html
@@ -198,17 +198,94 @@
     justify-content: space-between;
     align-items: center;
     margin-bottom: 1rem;
+    padding: 1rem;
     padding-bottom: 1rem;
     border-bottom: 2px solid #e5e7eb;
+    background: #f9fafb;
+    border-radius: 0.5rem 0.5rem 0 0;
+}
+
+.dark .canvas-header {
+    background: #374151;
+    border-bottom-color: #4b5563;
+}
+
+.dark .canvas-header h3 {
+    color: #f9fafb;
 }
 
 .canvas-header h3 {
     font-size: 1rem;
     font-weight: 600;
+    color: #1f2937;
     display: flex;
     align-items: center;
     gap: 0.5rem;
     margin: 0;
+}
+
+.canvas-header-controls {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+}
+
+.page-size-selector-group {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.page-size-label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: #374151;
+    margin: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+    .page-size-label {
+        color: #d1d5db;
+    }
+}
+
+.page-size-select {
+    padding: 0.5rem 0.75rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    background: white;
+    color: #1f2937;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.dark .page-size-select {
+    background: #374151;
+    border-color: #4b5563;
+    color: #f9fafb;
+}
+
+.dark .page-size-select:hover {
+    background: #4b5563;
+    border-color: #6b7280;
+}
+
+.dark .page-size-select:focus {
+    border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.2);
+}
+
+.page-size-select:hover {
+    border-color: #9ca3af;
+    background: #f9fafb;
+}
+
+.page-size-select:focus {
+    outline: none;
+    border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
 }
 
 .canvas-toolbar {
@@ -221,9 +298,21 @@
     border-radius: 0.5rem;
     border: 1px solid #e5e7eb;
     background: white;
+    color: #1f2937;
     cursor: pointer;
     transition: all 0.2s;
     font-size: 0.875rem;
+}
+
+.dark .canvas-toolbar button {
+    background: #374151;
+    border-color: #4b5563;
+    color: #f9fafb;
+}
+
+.dark .canvas-toolbar button:hover {
+    background: #4b5563;
+    border-color: #667eea;
 }
 
 .canvas-toolbar button:hover {
@@ -240,34 +329,112 @@
     overflow: auto;
 }
 
-/* Preview Panel */
-.preview-panel {
-    background: white;
-    border-radius: 0.75rem;
-    box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1);
-    padding: 1.5rem;
-    display: flex;
-    flex-direction: column;
-    max-height: 700px;
+/* Preview Modal */
+.preview-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 9999;
 }
 
-.preview-panel h3 {
-    font-size: 1rem;
-    font-weight: 600;
+.preview-modal-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.75);
+    backdrop-filter: blur(4px);
+}
+
+.preview-modal-content {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 90%;
+    max-width: 1200px;
+    max-height: 90vh;
+    background: white;
+    border-radius: 1rem;
+    box-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 10px 10px -5px rgb(0 0 0 / 0.04);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.dark .preview-modal-content {
+    background: #1f2937;
+    color: #f9fafb;
+}
+
+.preview-modal-header {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    margin: 0 0 1rem 0;
-    padding-bottom: 1rem;
+    justify-content: space-between;
+    padding: 1.5rem;
     border-bottom: 2px solid #e5e7eb;
 }
 
-#preview-frame {
+.dark .preview-modal-header {
+    border-bottom-color: #4b5563;
+}
+
+.preview-modal-header h3 {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0;
+    color: #1f2937;
+}
+
+.dark .preview-modal-header h3 {
+    color: #f9fafb;
+}
+
+.preview-modal-close {
+    background: transparent;
+    border: none;
+    font-size: 1.5rem;
+    color: #6b7280;
+    cursor: pointer;
+    padding: 0.25rem;
+    line-height: 1;
+    transition: color 0.2s;
+}
+
+.preview-modal-close:hover {
+    color: #1f2937;
+}
+
+.dark .preview-modal-close {
+    color: #9ca3af;
+}
+
+.dark .preview-modal-close:hover {
+    color: #f9fafb;
+}
+
+.preview-modal-body {
     flex: 1;
-    border: 1px solid #e5e7eb;
+    position: relative;
+    padding: 1.5rem;
+    overflow: auto;
+    min-height: 600px;
+    max-height: calc(90vh - 80px);
+}
+
+#preview-frame {
+    width: 100%;
+    min-height: 600px;
+    border: none;
     border-radius: 0.5rem;
     background: white;
-    width: 100%;
+}
+
+.dark #preview-frame {
+    background: #374151;
 }
 
 .preview-loading {
@@ -282,6 +449,11 @@
     align-items: center;
     justify-content: center;
     z-index: 10;
+    border-radius: 0.5rem;
+}
+
+.dark .preview-loading {
+    background: rgba(31, 41, 55, 0.95);
 }
 
 .preview-loading.active {
@@ -311,12 +483,23 @@
     overflow-y: auto;
 }
 
+.dark .properties-panel {
+    background: #1f2937;
+    color: #f9fafb;
+}
+
+.dark .properties-panel h3 {
+    color: #f9fafb;
+    border-bottom-color: #4b5563;
+}
+
 .properties-panel h3 {
     font-size: 1rem;
     font-weight: 600;
     margin: 0 0 1rem 0;
     padding-bottom: 1rem;
     border-bottom: 2px solid #e5e7eb;
+    color: #1f2937;
 }
 
 .property-group {
@@ -330,12 +513,34 @@
     color: #374151;
 }
 
+.dark .property-label {
+    color: #d1d5db;
+}
+
 .property-input {
     width: 100%;
     padding: 0.5rem;
     border: 1px solid #e5e7eb;
     border-radius: 0.5rem;
     font-size: 0.875rem;
+    background: white;
+    color: #1f2937;
+}
+
+.dark .property-input {
+    background: #374151;
+    border-color: #4b5563;
+    color: #f9fafb;
+}
+
+.dark .property-input:disabled {
+    background: #1f2937;
+    color: #6b7280;
+}
+
+.dark .property-input:focus {
+    border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.2);
 }
 
 .property-input:focus {
@@ -344,12 +549,61 @@
     box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
 }
 
+.property-input:disabled {
+    background: #f3f4f6;
+    color: #6b7280;
+    cursor: not-allowed;
+}
+
 /* Action Bar */
 .action-bar {
     display: flex;
     gap: 0.75rem;
     margin-bottom: 1.5rem;
     flex-wrap: wrap;
+}
+
+/* Button dark mode support */
+.dark .btn {
+    color: #f9fafb;
+}
+
+.dark .btn-secondary {
+    background: #4b5563;
+    border-color: #6b7280;
+    color: #f9fafb;
+}
+
+.dark .btn-secondary:hover {
+    background: #6b7280;
+    border-color: #9ca3af;
+}
+
+.dark .btn-primary {
+    background: #667eea;
+    border-color: #667eea;
+}
+
+.dark .btn-primary:hover {
+    background: #5568d3;
+}
+
+.dark .btn-info {
+    background: #0ea5e9;
+    border-color: #0ea5e9;
+}
+
+.dark .btn-info:hover {
+    background: #0284c7;
+}
+
+.dark .btn-danger {
+    background: #ef4444;
+    border-color: #ef4444;
+}
+
+.dark .btn-danger:hover {
+    background: #dc2626;
 }
 
 /* Info Box */
@@ -865,16 +1119,37 @@
                 <i class="fas fa-palette"></i>
                 {{ _('Design Canvas') }}
             </h3>
-            <div class="canvas-toolbar">
-                <button type="button" id="btn-zoom-in" title="{{ _('Zoom In') }}">
-                    <i class="fas fa-search-plus"></i>
-                </button>
-                <button type="button" id="btn-zoom-out" title="{{ _('Zoom Out') }}">
-                    <i class="fas fa-search-minus"></i>
-                </button>
-                <button type="button" id="btn-delete" title="{{ _('Delete Selected') }}">
-                    <i class="fas fa-trash"></i>
-                </button>
+            <div class="canvas-header-controls">
+                <div class="page-size-selector-group">
+                    <label class="page-size-label">{{ _('Page Size:') }}</label>
+                    <select id="page-size-selector" class="page-size-select">
+                        {% if all_templates %}
+                            {% for template in all_templates %}
+                                <option value="{{ template.page_size }}" {% if template.page_size == page_size %}selected{% endif %}>
+                                    {{ template.page_size }}
+                                </option>
+                            {% endfor %}
+                        {% else %}
+                            <option value="A4" {% if page_size == 'A4' %}selected{% endif %}>A4</option>
+                            <option value="Letter" {% if page_size == 'Letter' %}selected{% endif %}>Letter</option>
+                            <option value="Legal" {% if page_size == 'Legal' %}selected{% endif %}>Legal</option>
+                            <option value="A3" {% if page_size == 'A3' %}selected{% endif %}>A3</option>
+                            <option value="A5" {% if page_size == 'A5' %}selected{% endif %}>A5</option>
+                            <option value="Tabloid" {% if page_size == 'Tabloid' %}selected{% endif %}>Tabloid</option>
+                        {% endif %}
+                    </select>
+                </div>
+                <div class="canvas-toolbar">
+                    <button type="button" id="btn-zoom-in" title="{{ _('Zoom In') }}">
+                        <i class="fas fa-search-plus"></i>
+                    </button>
+                    <button type="button" id="btn-zoom-out" title="{{ _('Zoom Out') }}">
+                        <i class="fas fa-search-minus"></i>
+                    </button>
+                    <button type="button" id="btn-delete" title="{{ _('Delete Selected') }}">
+                        <i class="fas fa-trash"></i>
+                    </button>
+                </div>
             </div>
         </div>
         <div id="canvas-container"></div>
@@ -889,18 +1164,27 @@
         <div id="properties-content">
             <p class="text-sm text-gray-500 italic">{{ _('Select an element to edit its properties') }}</p>
         </div>
-        
-        <div style="margin-top: 1.5rem; padding-top: 1.5rem; border-top: 2px solid #e5e7eb;">
-            <h4 class="text-sm font-semibold mb-3">{{ _('Preview') }}</h4>
-            <div style="position: relative; height: 300px;">
+    </div>
+</div>
+
+<!-- Preview Modal -->
+<div id="preview-modal" class="preview-modal" style="display: none;">
+    <div class="preview-modal-overlay" id="preview-modal-overlay"></div>
+    <div class="preview-modal-content">
+        <div class="preview-modal-header">
+            <h3>{{ _('PDF Preview') }}</h3>
+            <button class="preview-modal-close" id="preview-modal-close" type="button">
+                <i class="fas fa-times"></i>
+            </button>
+        </div>
+        <div class="preview-modal-body">
             <div class="preview-loading" id="preview-loading">
                 <div class="text-center">
                     <div class="spinner mb-3"></div>
                     <p class="text-sm text-gray-600 font-medium">{{ _('Generating...') }}</p>
                 </div>
             </div>
-                <iframe id="preview-frame" style="width: 100%; height: 100%; border: 1px solid #e5e7eb; border-radius: 0.5rem;"></iframe>
-            </div>
+            <iframe id="preview-frame" style="width: 100%; height: 100%; border: none; border-radius: 0.5rem;"></iframe>
         </div>
     </div>
 </div>
@@ -908,6 +1192,7 @@
 <!-- Hidden Save Form -->
 <form id="form-save" method="POST" class="hidden">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <input type="hidden" name="page_size" id="save-page-size" value="{{ page_size }}">
     <textarea id="save-html" name="invoice_pdf_template_html"></textarea>
     <textarea id="save-css" name="invoice_pdf_template_css"></textarea>
     <textarea id="save-json" name="design_json"></textarea>
@@ -947,6 +1232,17 @@ const CSRF_TOKEN = {{ csrf_token()|tojson }};
 const PREVIEW_URL = {{ url_for('admin.pdf_layout_preview')|tojson }};
 const LOGO_URL = {{ (settings.get_logo_url() if settings.has_logo() else '')|tojson }};
 const SAVED_DESIGN_JSON = {{ (design_json if design_json else '')|tojson }};
+const CURRENT_PAGE_SIZE = {{ page_size|tojson }};
+
+// Page size dimensions in pixels at 72 DPI
+const PAGE_SIZE_DIMENSIONS = {
+    'A4': { width: 595, height: 842 },
+    'Letter': { width: 612, height: 792 },
+    'Legal': { width: 612, height: 1008 },
+    'A3': { width: 842, height: 1191 },
+    'A5': { width: 420, height: 595 },
+    'Tabloid': { width: 792, height: 1224 }
+};
 
 // Wait for Konva.js to load
 let konvaLoadAttempts = 0;
@@ -988,8 +1284,10 @@ function initializePDFEditor() {
     
     // Initialize Konva Stage
     const container = document.getElementById('canvas-container');
-    const width = 595; // A4 width in pixels at 72dpi
-    const height = 842; // A4 height in pixels
+    const currentSize = CURRENT_PAGE_SIZE || 'A4';
+    const dimensions = PAGE_SIZE_DIMENSIONS[currentSize] || PAGE_SIZE_DIMENSIONS['A4'];
+    const width = dimensions.width;
+    const height = dimensions.height;
     
     let stage = new Konva.Stage({
         container: 'canvas-container',
@@ -1020,13 +1318,17 @@ function initializePDFEditor() {
     
     // Add grid lines
     function drawGrid() {
+        // Get current stage dimensions
+        const stageWidth = stage.width();
+        const stageHeight = stage.height();
+        
         // Remove old grid if exists
         layer.find('.grid-line').forEach(line => line.destroy());
         
         // Draw vertical lines
-        for (let i = 0; i < width / gridSize; i++) {
+        for (let i = 0; i < stageWidth / gridSize; i++) {
             const line = new Konva.Line({
-                points: [i * gridSize, 0, i * gridSize, height],
+                points: [i * gridSize, 0, i * gridSize, stageHeight],
                 stroke: '#e0e0e0',
                 strokeWidth: i % 5 === 0 ? 0.5 : 0.25,
                 name: 'grid-line',
@@ -1037,9 +1339,9 @@ function initializePDFEditor() {
         }
         
         // Draw horizontal lines
-        for (let i = 0; i < height / gridSize; i++) {
+        for (let i = 0; i < stageHeight / gridSize; i++) {
             const line = new Konva.Line({
-                points: [0, i * gridSize, width, i * gridSize],
+                points: [0, i * gridSize, stageWidth, i * gridSize],
                 stroke: '#e0e0e0',
                 strokeWidth: i % 5 === 0 ? 0.5 : 0.25,
                 name: 'grid-line',
@@ -1049,7 +1351,9 @@ function initializePDFEditor() {
             line.moveToBottom();
         }
         
-        background.moveToBottom();
+        if (background) {
+            background.moveToBottom();
+        }
         layer.draw();
     }
     
@@ -1708,11 +2012,40 @@ function initializePDFEditor() {
     });
     
     // Generate preview
+    const previewModal = document.getElementById('preview-modal');
+    const previewModalOverlay = document.getElementById('preview-modal-overlay');
+    const previewModalClose = document.getElementById('preview-modal-close');
+    
+    function openPreviewModal() {
+        previewModal.style.display = 'block';
+        document.body.style.overflow = 'hidden';
+    }
+    
+    function closePreviewModal() {
+        previewModal.style.display = 'none';
+        document.body.style.overflow = '';
+    }
+    
+    previewModalOverlay.addEventListener('click', closePreviewModal);
+    previewModalClose.addEventListener('click', closePreviewModal);
+    
+    // Close on Escape key
+    document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape' && previewModal.style.display === 'block') {
+            closePreviewModal();
+        }
+    });
+    
     document.getElementById('btn-preview').addEventListener('click', function() {
         const { html, css } = generateCode();
         
+        openPreviewModal();
+        
         const loading = document.getElementById('preview-loading');
+        const frame = document.getElementById('preview-frame');
+        
         loading.classList.add('active');
+        frame.style.display = 'none';
         
         const fd = new FormData();
         fd.append('html', html);
@@ -1722,16 +2055,17 @@ function initializePDFEditor() {
         fetch(PREVIEW_URL, { method: 'POST', body: fd })
             .then(r => r.text())
             .then(html => {
-                const frame = document.getElementById('preview-frame');
                 const doc = frame.contentDocument || frame.contentWindow.document;
                 doc.open();
                 doc.write(html);
                 doc.close();
                 loading.classList.remove('active');
+                frame.style.display = 'block';
             })
             .catch(err => {
                 loading.classList.remove('active');
                 alert('Preview error: ' + err.message);
+                closePreviewModal();
             });
     });
     
@@ -1896,6 +2230,12 @@ function initializePDFEditor() {
             }
         });
         
+        // Get dimensions for current page size
+        const currentSizeHtml = CURRENT_PAGE_SIZE || 'A4';
+        const dimensionsHtml = PAGE_SIZE_DIMENSIONS[currentSizeHtml] || PAGE_SIZE_DIMENSIONS['A4'];
+        const widthPxHtml = dimensionsHtml.width;
+        const heightPxHtml = dimensionsHtml.height;
+        
         // Wrap in complete HTML document for proper PDF rendering
         const html = `<!DOCTYPE html>
 <html>
@@ -1904,7 +2244,7 @@ function initializePDFEditor() {
     <title>Invoice</title>
     <style>
         @page {
-            size: A4;
+            size: ${currentSizeHtml};
             margin: 0;
         }
         body {
@@ -1914,8 +2254,8 @@ function initializePDFEditor() {
         }
         .invoice-wrapper {
             position: relative;
-            width: 595px;
-            min-height: 842px;
+            width: ${widthPxHtml}px;
+            min-height: ${heightPxHtml}px;
             background: white;
             padding: 20px;
             box-sizing: border-box;
@@ -1956,8 +2296,14 @@ ${bodyContent}</div>
 </body>
 </html>`;
         
+        // Get dimensions for current page size
+        const currentSize = CURRENT_PAGE_SIZE || 'A4';
+        const dimensions = PAGE_SIZE_DIMENSIONS[currentSize] || PAGE_SIZE_DIMENSIONS['A4'];
+        const widthPx = dimensions.width;
+        const heightPx = dimensions.height;
+        
         const css = `@page {
-    size: A4;
+    size: ${currentSize};
     margin: 0;
 }
 body {
@@ -1967,8 +2313,8 @@ body {
 }
 .invoice-wrapper {
     position: relative;
-    width: 595px;
-    min-height: 842px;
+    width: ${widthPx}px;
+    min-height: ${heightPx}px;
     background: white;
     padding: 20px;
     box-sizing: border-box;
@@ -2029,6 +2375,34 @@ table tr:last-child td {
         document.getElementById('code-modal').classList.add('hidden');
     });
     
+    // Page size selector handler
+    const pageSizeSelector = document.getElementById('page-size-selector');
+    if (pageSizeSelector) {
+        // Set the current page size in the dropdown
+        if (CURRENT_PAGE_SIZE) {
+            pageSizeSelector.value = CURRENT_PAGE_SIZE;
+        }
+        
+        pageSizeSelector.addEventListener('change', async function() {
+            const newSize = this.value;
+            const confirmed = await showConfirm(
+                'Switching page size will reload the template. Any unsaved changes will be lost. Continue?',
+                {
+                    title: 'Switch Page Size',
+                    confirmText: 'Continue',
+                    cancelText: 'Cancel',
+                    variant: 'warning'
+                }
+            );
+            if (confirmed) {
+                window.location.href = '{{ url_for("admin.pdf_layout") }}?size=' + encodeURIComponent(newSize);
+            } else {
+                // Reset to current size
+                this.value = CURRENT_PAGE_SIZE || 'A4';
+            }
+        });
+    }
+    
     // Save
     document.getElementById('btn-save').addEventListener('click', function() {
         const { html, css } = generateCode();
@@ -2039,6 +2413,7 @@ table tr:last-child td {
         console.log('Has Items Table:', html.includes('<!-- Items Table Start -->'));
         console.log('Has Jinja2 loop:', html.includes('{' + '% for item in invoice.items'));
         console.log('Number of elements:', layer.children.length);
+        console.log('Page size:', CURRENT_PAGE_SIZE);
         
         // Log all Groups to see if items-table is there
         layer.children.forEach((child, idx) => {
@@ -2050,6 +2425,7 @@ table tr:last-child td {
         document.getElementById('save-html').value = html;
         document.getElementById('save-css').value = css;
         document.getElementById('save-json').value = JSON.stringify(stage.toJSON());
+        document.getElementById('save-page-size').value = CURRENT_PAGE_SIZE || pageSizeSelector.value;
         document.getElementById('form-save').submit();
     });
     
@@ -2233,30 +2609,67 @@ table tr:last-child td {
             try {
                 const savedJson = JSON.parse(SAVED_DESIGN_JSON);
                 
+                // Get current page size dimensions
+                const currentSize = CURRENT_PAGE_SIZE || 'A4';
+                const dimensions = PAGE_SIZE_DIMENSIONS[currentSize] || PAGE_SIZE_DIMENSIONS['A4'];
+                
+                // Update saved JSON dimensions to match current page size
+                if (savedJson.attrs) {
+                    savedJson.attrs.width = dimensions.width;
+                    savedJson.attrs.height = dimensions.height;
+                }
+                
                 // Clear current layer
                 layer.destroyChildren();
                 
                 // Recreate stage from saved JSON
                 const restoredStage = Konva.Node.create(savedJson, 'canvas-container');
                 
+                // Ensure stage has correct dimensions
+                restoredStage.width(dimensions.width);
+                restoredStage.height(dimensions.height);
+                
                 // Replace current stage
                 stage.destroy();
                 stage = restoredStage;
                 layer = stage.children[0];
                 
-                // Find background by name
-                background = layer.findOne('[name="background"]') || layer.children[0];
+                // Find or create background by name and resize it
+                background = layer.findOne('[name="background"]');
+                if (background) {
+                    if (background.className === 'Rect') {
+                        background.width(dimensions.width);
+                        background.height(dimensions.height);
+                    }
+                } else {
+                    // Create background if it doesn't exist
+                    background = new Konva.Rect({
+                        x: 0,
+                        y: 0,
+                        width: dimensions.width,
+                        height: dimensions.height,
+                        fill: 'white',
+                        name: 'background'
+                    });
+                    layer.add(background);
+                    background.moveToBottom();
+                }
                 
-                // Re-setup selections for all elements
+                // Redraw grid for new size
+                drawGrid();
+                
+                // Re-setup selections for all elements (skip background and grid lines)
                 layer.children.forEach(child => {
-                    if (child !== background && child.className !== 'Transformer') {
+                    if (child !== background && 
+                        child.className !== 'Transformer' && 
+                        !(child.className === 'Line' && child.attrs.name === 'grid-line')) {
                         setupSelection(child);
                         elements.push({ type: child.attrs.name || child.className, node: child });
                     }
                 });
                 
                 layer.draw();
-                console.log('✅ Saved design loaded successfully');
+                console.log('✅ Saved design loaded successfully for size:', currentSize);
             } catch (error) {
                 console.error('Failed to load saved design:', error);
                 console.log('Loading default layout instead...');


### PR DESCRIPTION
Add the ability to create and manage PDF invoice templates for different page sizes (A4, Letter, Legal, A3, A5, Tabloid) with independent templates for each size.

Features:
- Database migration to create invoice_pdf_templates table with page_size column and default templates for all supported sizes
- New InvoicePDFTemplate model with helper methods for template management
- Page size selector dropdown in canvas editor with dynamic canvas resizing
- Size selection in invoice export view
- Each page size maintains its own template (HTML, CSS, design JSON)
- Preview functionality converted to full-screen modal popup

PDF Generation:
- Updated InvoicePDFGenerator to accept page_size parameter
- Dynamic @page rule updates in CSS based on selected size
- Removed conflicting @page rules from HTML inline styles when separate CSS exists
- Template content preserved exactly as saved (no whitespace stripping)
- Fallback logic: size-specific template → legacy Settings template → default

UI/UX Improvements:
- Styled page size selector to match app theme with dark mode support
- Fixed canvas editor header styling and readability
- Canvas correctly resizes when switching between page sizes
- Unsaved changes confirmation uses app's standard modal
- All editor controls properly styled for dark/light mode
- Preview opens in modal instead of small side window

Bug Fixes:
- Fixed migration KeyError by correcting down_revision reference
- Fixed DatatypeMismatch error by using boolean TRUE instead of integer
- Fixed template content mismatch (logo positions) by preserving HTML
- Fixed page size not being applied by ensuring @page rules are updated
- Fixed f-string syntax error in _generate_css by using .format() instead
- Fixed debug_print scope issue in _render_from_custom_template

Debugging:
- Added comprehensive debug logging to PDF generation flow
- Debug output visible in Docker console for troubleshooting
- Logs template retrieval, @page size updates, and final CSS content

Files Changed:
- migrations/versions/041_add_invoice_pdf_templates_table.py (new)
- app/models/invoice_pdf_template.py (new)
- app/models/__init__.py (register new model)
- app/routes/admin.py (template management by size)
- app/routes/invoices.py (page size parameter, debug logging)
- app/utils/pdf_generator.py (page size support, debug logging)
- templates/admin/pdf_layout.html (size selector, canvas resizing, modal)
- app/templates/invoices/view.html (size selector for export)