### PR TITLE
perf: optimize task listing and improve version management

### DIFF
--- a/app/routes/api_v1.py
+++ b/app/routes/api_v1.py
@@ -133,10 +133,17 @@ def api_info():
             documentation_url:
               type: string
     """
+    # Get app version from setup.py (single source of truth)
+    from app.config.analytics_defaults import get_version_from_setup
+    app_version = get_version_from_setup()
+    if app_version == "unknown":
+        # Fallback to config or default
+        app_version = current_app.config.get("APP_VERSION", "1.0.0")
+    
     return jsonify(
         {
             "api_version": "v1",
-            "app_version": current_app.config.get("APP_VERSION", "1.0.0"),
+            "app_version": app_version,
             "documentation_url": "/api/docs",
             "authentication": "API Token (Bearer or X-API-Key header)",
             "endpoints": {

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='timetracker',
-    version='4.5.0',
+    version='4.5.1',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
- Bump version to 4.5.1
- Refactor version retrieval: make get_version_from_setup() public and add multiple path fallbacks for better reliability in production and development environments
- Optimize task listing performance:
  * Replace joinedload with selectinload to avoid cartesian product issues
  * Implement optimized pagination that avoids expensive count queries when possible
  * Move AJAX request check earlier to skip unnecessary filter data loading
  * Add query limits to filter dropdowns (projects: 500, users: 200)
  * Optimize permission checks by checking is_admin first (no DB query)
- Update API info endpoint and context processor to use centralized version retrieval
- Maintain backward compatibility with _get_version_from_setup alias