### PR TITLE
fix(desktop): use modern Node for Vite builds

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -1,5 +1,8 @@
 name: Build Desktop Apps
 
+env:
+  NODE_VERSION: '24'
+
 on:
   push:
     branches: [ main, develop ]
@@ -19,9 +22,9 @@ jobs:
       - uses: actions/checkout@v3
       
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: ${{ env.NODE_VERSION }}
       
       - name: Generate desktop icons
         run: |
@@ -52,9 +55,9 @@ jobs:
       - uses: actions/checkout@v3
       
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: ${{ env.NODE_VERSION }}
       
       - name: Generate desktop icons
         run: |
@@ -83,9 +86,9 @@ jobs:
       - uses: actions/checkout@v3
       
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: ${{ env.NODE_VERSION }}
       
       - name: Generate desktop icons
         run: |

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -41,6 +41,7 @@ env:
   # - DOCKERHUB_TOKEN (recommended) or DOCKERHUB_PASSWORD
   DOCKERHUB_IMAGE: driesp/timetracker
   PYTHON_VERSION: '3.11'
+  NODE_VERSION: '24'
 
 jobs:
   # ============================================================================
@@ -820,7 +821,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: ${{ env.NODE_VERSION }}
       
       - name: Generate desktop icons
         run: |
@@ -857,7 +858,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: ${{ env.NODE_VERSION }}
       
       - name: Generate desktop icons
         run: |
@@ -896,7 +897,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: ${{ env.NODE_VERSION }}
       
       - name: Generate desktop icons
         run: |

--- a/desktop/test/react_renderer_package.test.js
+++ b/desktop/test/react_renderer_package.test.js
@@ -12,6 +12,8 @@ test('desktop package builds the React renderer with Vite', () => {
   assert.ok(pkg.dependencies['react-dom']);
   assert.ok(pkg.devDependencies.vite);
   assert.ok(pkg.devDependencies['@vitejs/plugin-react']);
+  assert.ok(fs.existsSync(path.join(root, 'vite.config.mjs')));
+  assert.ok(!fs.existsSync(path.join(root, 'vite.config.js')));
   assert.ok(pkg.build.files.includes('dist-renderer/**/*'));
 });
 
@@ -27,4 +29,14 @@ test('main process store IPC is limited to known desktop settings', () => {
   assert.match(mainSource, /api_token_server_url/);
   assert.match(mainSource, /theme_mode/);
   assert.match(mainSource, /auto_sync/);
+});
+
+test('desktop GitHub workflows use a Vite-compatible Node version', () => {
+  const workflowRoot = path.resolve(root, '..', '.github', 'workflows');
+  const buildDesktop = fs.readFileSync(path.join(workflowRoot, 'build-desktop.yml'), 'utf8');
+  const release = fs.readFileSync(path.join(workflowRoot, 'cd-release.yml'), 'utf8');
+  for (const source of [buildDesktop, release]) {
+    assert.match(source, /NODE_VERSION:\s+'24'/);
+    assert.doesNotMatch(source, /node-version:\s+'18'/);
+  }
 });

--- a/desktop/vite.config.mjs
+++ b/desktop/vite.config.mjs
@@ -1,8 +1,11 @@
-const path = require('path');
-const { defineConfig } = require('vite');
-const react = require('@vitejs/plugin-react');
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
-module.exports = defineConfig({
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
   root: path.resolve(__dirname, 'src/renderer-react'),
   base: './',
   plugins: [react()],


### PR DESCRIPTION
Run desktop packaging workflows on Node 24 and load Vite through an ESM config so macOS, Linux, and Windows builds use a runtime compatible with Vite 7.

## Description

Brief description of the change and why it's needed.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor (no functional change)

## Checklist

- [ ] My code follows the project's style guidelines (Black, flake8).
- [ ] I have added/updated tests for my changes.
- [ ] All tests pass locally (e.g. `pytest`).
- [ ] I have updated the documentation if needed.
- [ ] For user-facing changes, I have added an entry to the **Unreleased** section of [CHANGELOG.md](../CHANGELOG.md).

## Related issues

Fixes # (issue number, if applicable)

---

See [CONTRIBUTING.md](../CONTRIBUTING.md) and [CHANGELOG.md](../CHANGELOG.md) for guidelines.
