### PR TITLE
fix(ui): hide donate UI on instances with an activated supporter license

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1260,7 +1260,7 @@
                             <i class="fas fa-wand-magic-sparkles"></i>
                         </button>
                         {% endif %}
-                        {% if current_user.is_authenticated %}
+                        {% if current_user.is_authenticated and not is_license_activated %}
                         <button type="button" id="headerSupportBtn" class="hidden sm:inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-sm font-medium text-amber-800 dark:text-amber-200 bg-amber-500/15 hover:bg-amber-500/25 border border-amber-500/30 dark:border-amber-500/40 focus:outline-none focus:ring-2 focus:ring-amber-500/40" title="{{ _('Support TimeTracker') }}">
                             <i class="fas fa-heart text-amber-600 dark:text-amber-300" aria-hidden="true"></i>
                             <span class="max-w-[10rem] truncate">{{ _('Support TimeTracker') }}</span>
@@ -1325,7 +1325,7 @@
                             {% if current_user.is_authenticated %}
                             <li><a href="{{ url_for('user.license') }}" class="flex items-center gap-2 px-4 py-2 text-sm text-text-light dark:text-text-dark hover:bg-gray-100 dark:hover:bg-gray-700"><i class="fas fa-key w-4"></i> {{ _('License') }}</a></li>
                             {% endif %}
-                            {% if current_user.is_authenticated %}
+                            {% if current_user.is_authenticated and not is_license_activated %}
                             <li><button type="button" class="js-open-support-modal w-full text-left flex flex-col gap-0.5 px-4 py-2 text-sm text-amber-600 dark:text-amber-400 hover:bg-gray-100 dark:hover:bg-gray-700"><span class="font-medium"><i class="fas fa-heart w-4" aria-hidden="true"></i> {{ _('Support TimeTracker') }}</span><span class="text-xs text-text-muted-light dark:text-text-muted-dark">{{ _('Donate or get a supporter license') }}</span></button></li>
                             {% endif %}
                             <li class="border-t border-border-light dark:border-border-dark"><a href="{{ url_for('auth.logout') }}" class="flex items-center gap-2 px-4 py-2 text-sm text-rose-600 dark:text-rose-400 hover:bg-gray-100 dark:hover:bg-gray-700"><i class="fas fa-sign-out-alt w-4"></i> {{ _('Logout') }}</a></li>

--- a/app/templates/components/support_modal.html
+++ b/app/templates/components/support_modal.html
@@ -36,20 +36,26 @@
                 </div>
                 <p id="supportSocialLine" class="text-xs text-text-muted-light dark:text-text-muted-dark text-center">{{ _('Trusted by teams and freelancers who want simple, reliable time tracking.') }}</p>
                 <p id="supportModalOffline" class="hidden text-sm text-amber-700 dark:text-amber-300"></p>
+                {% if not is_license_activated %}
                 <div class="flex flex-col sm:flex-row gap-2">
                     <a href="#" rel="noopener noreferrer" data-support-tier="eur5" class="support-tier-btn btn btn-secondary text-center flex-1">{{ _('Donate') }} (€5)</a>
                     <a href="#" rel="noopener noreferrer" data-support-tier="eur10" class="support-tier-btn btn btn-secondary text-center flex-1">{{ _('Donate') }} (€10)</a>
                     <a href="#" rel="noopener noreferrer" data-support-tier="eur25" class="support-tier-btn btn btn-secondary text-center flex-1">{{ _('Donate') }} (€25)</a>
                 </div>
+                {% endif %}
                 <div class="flex flex-col sm:flex-row gap-2">
+                    {% if not is_license_activated %}
                     <a href="{{ support_purchase_url }}" target="_blank" rel="noopener noreferrer" data-support-tier="license" class="btn btn-primary text-center flex-1">
                         {{ _('Buy license (€25)') }} <i class="fas fa-external-link-alt text-xs ml-1" aria-hidden="true"></i>
                     </a>
+                    {% endif %}
                     <button type="button" id="supportShareBtn" class="btn btn-secondary text-center flex-1">{{ _('Love TimeTracker? Share it') }}</button>
                 </div>
+                {% if not is_license_activated %}
                 <p class="text-xs text-text-muted-light dark:text-text-muted-dark">
                     {{ _('A license is a supporter badge — it does not lock features. You keep full access either way.') }}
                 </p>
+                {% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Problem

After redeeming a supporter license (so `settings.donate_ui_hidden = true` and `is_license_activated` is `True`), three donate-related UI elements still render for every authenticated user:

1. The header `headerSupportBtn` in `base.html` (the right-aligned "♥ Support TimeTracker" button)
2. The user-menu dropdown "Support TimeTracker" entry in `base.html`
3. Inside `components/support_modal.html`: the three Donate (€5/€10/€25) buttons, the "Buy license (€25)" button, and the "A license is a supporter badge…" footnote

Other donate prompts (sidebar item, dashboard widget, about page, reports page, help page) already gate on `is_license_activated`. These three spots slipped through, so even users on a licensed instance keep seeing donate CTAs and a "Buy license" button despite already having one.

## Reproduction

1. On a fresh instance, redeem a valid Ed25519-signed support code via Settings → License (or set `donate_ui_hidden = true` directly in the `settings` row).
2. Reload any page as any authenticated user.
3. Observe: header still shows the amber "Support TimeTracker" button. User dropdown still has a "Support TimeTracker" entry. Opening the modal (e.g. via the dropdown) shows Donate / Buy license buttons even though the title copy already says "Thank you for being a supporter".

The "Supporter" badge next to the username does correctly render (it gates on `is_license_activated`), making the inconsistency more obvious.

## Fix

Wrap each of the three spots in `{% if not is_license_activated %}`:

- `app/templates/base.html` — header support button (line ~1263) and user-dropdown menu entry (line ~1328)
- `app/templates/components/support_modal.html` — the two donate-button rows and the closing license-info paragraph

The "Love TimeTracker? Share it" button is intentionally left visible — sharing is still useful regardless of license state.

The modal title copy already adapts to license state via the existing branch in `support_modal.html` lines 11–15, so it stays correct.

The "License" entry in the user dropdown is left unconditional — it remains the place where someone manages an existing license.

## Diff size

```
app/templates/base.html                     | 4 ++--
app/templates/components/support_modal.html | 6 ++++++
2 files changed, 8 insertions(+), 2 deletions(-)
```

No backend or database changes.

## Verification

On a licensed instance: the three spots are gone; only the supporter thank-you copy and the Share button remain in the modal.
On an unlicensed instance: behaviour unchanged — every donate prompt still renders as before.

Tested against `v5.5.2`.