### PR TITLE
fix: two runtime bugs flagged by flake8 (NameError in auth, UnboundLocalError in timer)

### DIFF
--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from flask import (
     Blueprint,
     current_app,

--- a/app/routes/timer.py
+++ b/app/routes/timer.py
@@ -172,7 +172,7 @@ def start_timer():
         current_app.logger.warning("Start timer denied: user has no access to client_id=%s", client_id)
         return redirect(url_for("main.dashboard"))
 
-    can_start, _ = TimeTrackingService().can_start_timer(current_user.id)
+    can_start, _unused = TimeTrackingService().can_start_timer(current_user.id)
     if not can_start:
         flash(_("You already have an active timer. Stop it before starting a new one."), "error")
         current_app.logger.info("Start timer blocked: user already has an active timer")
@@ -336,7 +336,7 @@ def start_timer_from_template(template_id):
     # Load template
     template = TimeEntryTemplate.query.filter_by(id=template_id, user_id=current_user.id).first_or_404()
 
-    can_start, _ = TimeTrackingService().can_start_timer(current_user.id)
+    can_start, _unused = TimeTrackingService().can_start_timer(current_user.id)
     if not can_start:
         flash(_("You already have an active timer. Stop it before starting a new one."), "error")
         return redirect(url_for("main.dashboard"))
@@ -450,7 +450,7 @@ def start_timer_for_project(project_id):
         current_app.logger.warning("Start timer (GET) denied: user has no access to project_id=%s", project_id)
         return redirect(url_for("main.dashboard"))
 
-    can_start, _ = TimeTrackingService().can_start_timer(current_user.id)
+    can_start, _unused = TimeTrackingService().can_start_timer(current_user.id)
     if not can_start:
         flash(_("You already have an active timer. Stop it before starting a new one."), "error")
         current_app.logger.info("Start timer (GET) blocked: user already has an active timer")
@@ -2019,7 +2019,7 @@ def resume_timer_by_id(timer_id):
         flash(_("You can only resume your own timers"), "error")
         return redirect(url_for("main.dashboard"))
 
-    can_start, _ = TimeTrackingService().can_start_timer(current_user.id)
+    can_start, _unused = TimeTrackingService().can_start_timer(current_user.id)
     if not can_start:
         flash("You already have an active timer. Stop it before resuming another one.", "error")
         current_app.logger.info("Resume timer blocked: user already has an active timer")


### PR DESCRIPTION
## Summary

Two genuine runtime bugs in `v5.5.2`. flake8 already flags them (F821, F823) — they're not stylistic.

## Bug 1 — `app/routes/auth.py:620` — `NameError: datetime`

`current_user.two_factor_confirmed_at = datetime.utcnow()` references `datetime` without importing it. The 2FA confirmation route raises `NameError: name 'datetime' is not defined` whenever a user finalises 2FA setup.

```python
# Top of file (existing imports — none of them brings in datetime)
from flask import (...)
from flask_babel import gettext as _
from flask_login import current_user, login_required, login_user, logout_user
from app import db, limiter, log_event, oauth, track_event
```

flake8: `app/routes/auth.py:620:52: F821 undefined name 'datetime'`

Fix: add `from datetime import datetime` to the import block.

## Bug 2 — `app/routes/timer.py` — `UnboundLocalError` on `_`

Module level:
```python
from flask_babel import gettext as _
```

Four functions then unpack:
```python
can_start, _ = TimeTrackingService().can_start_timer(current_user.id)
```
at lines 175, 339, 453, 2022. Python's scoping promotes `_` to a function-local for the entire enclosing scope, shadowing the imported translation function. Three `flash(_("..."))` calls in those functions sit BEFORE the local assignment (lines 171, 449, 2019) and now reference an uninitialised local — `UnboundLocalError` at runtime.

flake8:
```
app/routes/timer.py:171:15: F823 local variable '_' defined in enclosing scope on line 5 referenced before assignment
app/routes/timer.py:449:15: F823 local variable '_' defined in enclosing scope on line 5 referenced before assignment
app/routes/timer.py:2019:15: F823 local variable '_' defined in enclosing scope on line 5 referenced before assignment
```

Fix: rename the throwaway slot from `_` to `_unused` in all four `can_start_timer` unpackings. The three previously-broken `flash(_("..."))` calls now resolve the translation alias as intended.

## Reproduction

- Bug 1: enable 2FA on a user, complete the verification step → 500 with `NameError`.
- Bug 2: trigger any of the three timer paths under the conditions where the access check fires (start timer with no project access; start timer GET path with no access; resume another user's timer) → 500 with `UnboundLocalError`.

## Diff size

```
app/routes/auth.py  | 2 ++
app/routes/timer.py | 8 ++++----
2 files changed, 6 insertions(+), 4 deletions(-)
```

No behavioural change beyond bug elimination. Tested against `v5.5.2`.