### PR TITLE
fix(uploads,kanban): write all attachment routes to mounted volume; eliminate validator-drift bugs

### DIFF
--- a/app/models/kanban_column.py
+++ b/app/models/kanban_column.py
@@ -107,12 +107,39 @@ class KanbanColumn(db.Model):
             return None
 
     @classmethod
+    def get_columns_with_global_fallback(cls, project_id=None):
+        """Return the column objects the kanban UI should render for a project.
+
+        If the project has project-specific columns, return those.
+        Otherwise return the global columns (project_id IS NULL).
+        Mirrors the validator behaviour in get_valid_status_keys().
+        """
+        cols = cls.get_active_columns(project_id=project_id)
+        if not cols and project_id is not None:
+            cols = cls.get_active_columns(project_id=None)
+        return cols
+
+    @classmethod
     def get_valid_status_keys(cls, project_id=None):
-        """Get list of all valid status keys (for validation). If project_id is None, returns global column keys."""
+        """Get list of all valid status keys (for validation).
+
+        If project_id is None, returns global column keys.
+
+        If project_id is set but the project has no project-specific
+        columns, fall back to the configured global columns. The kanban
+        UI renders global columns in that case, so the validator must
+        accept the same set — otherwise drops to globally-defined columns
+        like "on_hold" come back as 400 "Invalid status".
+        """
         columns = cls.get_active_columns(project_id=project_id)
+        if not columns and project_id is not None:
+            columns = cls.get_active_columns(project_id=None)
         if not columns:
-            # Fallback to default statuses if table doesn't exist
-            return ["todo", "in_progress", "review", "done", "cancelled"]
+            # Last-ditch fallback if even global columns are missing
+            # (e.g. table not yet seeded during a fresh migration).
+            # Keep this aligned with the keys initialize_default_columns seeds
+            # plus any well-known optional columns users tend to enable.
+            return ["todo", "in_progress", "review", "done", "on_hold", "cancelled"]
         return [col.key for col in columns]
 
     @classmethod

--- a/app/routes/client_portal.py
+++ b/app/routes/client_portal.py
@@ -1327,7 +1327,7 @@ def download_attachment(attachment_id):
     if attachment and attachment.client_id == client.id and attachment.is_visible_to_client:
         # Get file directory - file_path is relative to static or uploads folder
         if attachment.file_path.startswith("uploads/"):
-            file_dir = os.path.join(current_app.root_path, "..", "uploads")
+            file_dir = os.path.join(current_app.root_path, "..", "app/static/uploads")
             filename = os.path.basename(attachment.file_path)
         else:
             file_dir = os.path.join(current_app.root_path, "static", os.path.dirname(attachment.file_path))
@@ -1344,7 +1344,7 @@ def download_attachment(attachment_id):
         if project and project.client_id == client.id and attachment.is_visible_to_client:
             # Get file directory
             if attachment.file_path.startswith("uploads/"):
-                file_dir = os.path.join(current_app.root_path, "..", "uploads")
+                file_dir = os.path.join(current_app.root_path, "..", "app/static/uploads")
                 filename = os.path.basename(attachment.file_path)
             else:
                 file_dir = os.path.join(current_app.root_path, "static", os.path.dirname(attachment.file_path))

--- a/app/routes/clients.py
+++ b/app/routes/clients.py
@@ -1254,7 +1254,7 @@ def upload_client_attachment(client_id):
 
     # File upload configuration
     ALLOWED_EXTENSIONS = {"png", "jpg", "jpeg", "gif", "pdf", "doc", "docx", "txt", "xls", "xlsx", "zip", "rar"}
-    UPLOAD_FOLDER = "uploads/client_attachments"
+    UPLOAD_FOLDER = "app/static/uploads/client_attachments"
     MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
 
     def allowed_file(filename):

--- a/app/routes/comments.py
+++ b/app/routes/comments.py
@@ -276,7 +276,7 @@ def upload_comment_attachment(comment_id):
 
     # File upload configuration
     ALLOWED_EXTENSIONS = {"png", "jpg", "jpeg", "gif", "pdf", "doc", "docx", "txt", "xls", "xlsx", "zip", "rar"}
-    UPLOAD_FOLDER = "uploads/comment_attachments"
+    UPLOAD_FOLDER = "app/static/uploads/comment_attachments"
     MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
 
     def allowed_file(filename):

--- a/app/routes/invoices.py
+++ b/app/routes/invoices.py
@@ -829,7 +829,8 @@ def bulk_update_status():
         return redirect(url_for("invoices.list_invoices"))
 
     # Validate status
-    valid_statuses = ["draft", "sent", "paid", "overdue", "cancelled"]
+    # Mirror the single-update validator so bulk update can also set "issued".
+    valid_statuses = ["draft", "issued", "sent", "paid", "overdue", "cancelled"]
     if not new_status or new_status not in valid_statuses:
         flash(_("Invalid status value"), "error")
         return redirect(url_for("invoices.list_invoices"))

--- a/app/routes/quotes.py
+++ b/app/routes/quotes.py
@@ -917,7 +917,8 @@ def send_quote(quote_id):
         send_quote_sent_notification(quote, quote.creator)
 
     # Notify admins
-    admins = User.query.filter_by(role="admin", is_active=True).all()
+    # Use the User.is_admin property so RBAC Role-based admins are notified, not just legacy role="admin" users.
+    admins = [u for u in User.query.filter_by(is_active=True).all() if u.is_admin]
     for admin in admins:
         if admin.id != quote.creator_id and admin.email:
             send_quote_sent_notification(quote, admin)
@@ -1022,8 +1023,8 @@ def accept_quote(quote_id):
         if quote.creator and quote.creator.email:
             send_quote_accepted_notification(quote, quote.creator)
 
-        # Notify admins
-        admins = User.query.filter_by(role="admin", is_active=True).all()
+        # Notify admins (use User.is_admin so RBAC Role-based admins are notified, not just legacy role="admin").
+        admins = [u for u in User.query.filter_by(is_active=True).all() if u.is_admin]
         for admin in admins:
             if admin.id != quote.creator_id and admin.email:
                 send_quote_accepted_notification(quote, admin)
@@ -1117,7 +1118,7 @@ def upload_attachment(quote_id):
 
     # File upload configuration
     ALLOWED_EXTENSIONS = {"png", "jpg", "jpeg", "gif", "pdf", "doc", "docx", "txt", "xls", "xlsx", "zip", "rar"}
-    UPLOAD_FOLDER = "uploads/quote_attachments"
+    UPLOAD_FOLDER = "app/static/uploads/quote_attachments"
     MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
 
     def allowed_file(filename):
@@ -1317,7 +1318,8 @@ def request_approval(quote_id):
     from app.utils.email import send_quote_approval_request_notification
 
     # Notify admins (default approvers)
-    admins = User.query.filter_by(role="admin", is_active=True).all()
+    # Use the User.is_admin property so RBAC Role-based admins are notified, not just legacy role="admin" users.
+    admins = [u for u in User.query.filter_by(is_active=True).all() if u.is_admin]
     for admin in admins:
         if admin.email:
             send_quote_approval_request_notification(quote, admin)

--- a/app/routes/tasks.py
+++ b/app/routes/tasks.py
@@ -138,7 +138,11 @@ def list_tasks():
     kanban_columns = KanbanColumn.get_active_columns(project_id=None) if KanbanColumn else []
 
     # Pre-calculate task counts by status for summary cards (avoid template iteration)
-    task_counts = {"todo": 0, "in_progress": 0, "review": 0, "done": 0}
+    task_counts = (
+        {col.key: 0 for col in kanban_columns}
+        if kanban_columns
+        else {"todo": 0, "in_progress": 0, "review": 0, "done": 0}
+    )
     for task in result["tasks"]:
         if task.status in task_counts:
             task_counts[task.status] += 1
@@ -191,7 +195,7 @@ def create_task():
             flash(_("Project and task name are required"), "error")
             projects = Project.query.filter_by(status="active").order_by(Project.name).all()
             users = User.query.order_by(User.username).all()
-            return render_template("tasks/create.html", projects=projects, users=users)
+            return render_template("tasks/create.html", projects=projects, users=users, kanban_columns=KanbanColumn.get_active_columns(project_id=None))
 
         # Sanitize and validate name
         try:
@@ -200,7 +204,7 @@ def create_task():
             flash(_("Invalid task name: %(error)s", error=str(e)), "error")
             projects = Project.query.filter_by(status="active").order_by(Project.name).all()
             users = User.query.order_by(User.username).all()
-            return render_template("tasks/create.html", projects=projects, users=users)
+            return render_template("tasks/create.html", projects=projects, users=users, kanban_columns=KanbanColumn.get_active_columns(project_id=None))
 
         # Validate project exists
         project = Project.query.get(project_id)
@@ -208,15 +212,16 @@ def create_task():
             flash(_("Selected project does not exist"), "error")
             projects = Project.query.filter_by(status="active").order_by(Project.name).all()
             users = User.query.order_by(User.username).all()
-            return render_template("tasks/create.html", projects=projects, users=users)
+            return render_template("tasks/create.html", projects=projects, users=users, kanban_columns=KanbanColumn.get_active_columns(project_id=None))
 
         # Validate priority
         if priority not in ["low", "medium", "high", "urgent"]:
             priority = "medium"
 
-        # Validate initial status
+        # Validate initial status against the configured kanban columns
         status = request.form.get("status", "todo").strip()
-        if status not in ("todo", "in_progress", "review", "done", "cancelled"):
+        valid_statuses = KanbanColumn.get_valid_status_keys(project_id=project_id)
+        if status not in valid_statuses:
             status = "todo"
 
         # Parse estimated hours
@@ -238,7 +243,7 @@ def create_task():
                 flash(_("Invalid due date format"), "error")
                 projects = Project.query.filter_by(status="active").order_by(Project.name).all()
                 users = User.query.order_by(User.username).all()
-                return render_template("tasks/create.html", projects=projects, users=users)
+                return render_template("tasks/create.html", projects=projects, users=users, kanban_columns=KanbanColumn.get_active_columns(project_id=None))
 
         # Gantt color (hex e.g. #3b82f6)
         color_val = request.form.get("color", "").strip()
@@ -273,7 +278,7 @@ def create_task():
             flash(_(result["message"]), "error")
             projects = Project.query.filter_by(status="active").order_by(Project.name).all()
             users = User.query.order_by(User.username).all()
-            return render_template("tasks/create.html", projects=projects, users=users)
+            return render_template("tasks/create.html", projects=projects, users=users, kanban_columns=KanbanColumn.get_active_columns(project_id=None))
 
         task = result["task"]
 
@@ -308,7 +313,7 @@ def create_task():
     projects = Project.query.filter_by(status="active").order_by(Project.name).all()
     users = User.query.order_by(User.username).all()
 
-    return render_template("tasks/create.html", projects=projects, users=users)
+    return render_template("tasks/create.html", projects=projects, users=users, kanban_columns=KanbanColumn.get_active_columns(project_id=None))
 
 
 @tasks_bp.route("/tasks/<int:task_id>")
@@ -413,14 +418,14 @@ def edit_task(task_id):
         # Validate required fields
         if not name:
             flash(_("Task name is required"), "error")
-            return render_template("tasks/edit.html", task=task, projects=projects, users=users)
+            return render_template("tasks/edit.html", task=task, projects=projects, users=users, kanban_columns=KanbanColumn.get_columns_with_global_fallback(project_id=task.project_id))
 
         # Sanitize and validate name
         try:
             name = validate_string(sanitize_input(name), min_length=1, max_length=200)
         except Exception as e:
             flash(_("Invalid task name: %(error)s", error=str(e)), "error")
-            return render_template("tasks/edit.html", task=task, projects=projects, users=users)
+            return render_template("tasks/edit.html", task=task, projects=projects, users=users, kanban_columns=KanbanColumn.get_columns_with_global_fallback(project_id=task.project_id))
 
         # Sanitize description
         if description:
@@ -432,11 +437,11 @@ def edit_task(task_id):
         # Validate project selection
         if not project_id:
             flash(_("Project is required"), "error")
-            return render_template("tasks/edit.html", task=task, projects=projects, users=users)
+            return render_template("tasks/edit.html", task=task, projects=projects, users=users, kanban_columns=KanbanColumn.get_columns_with_global_fallback(project_id=task.project_id))
         new_project = Project.query.filter_by(id=project_id, status="active").first()
         if not new_project:
             flash(_("Selected project does not exist or is inactive"), "error")
-            return render_template("tasks/edit.html", task=task, projects=projects, users=users)
+            return render_template("tasks/edit.html", task=task, projects=projects, users=users, kanban_columns=KanbanColumn.get_columns_with_global_fallback(project_id=task.project_id))
 
         # Validate priority
         if priority not in ["low", "medium", "high", "urgent"]:
@@ -459,7 +464,7 @@ def edit_task(task_id):
                 due_date = datetime.strptime(due_date_str, "%Y-%m-%d").date()
             except ValueError:
                 flash(_("Invalid due date format"), "error")
-                return render_template("tasks/edit.html", task=task, projects=projects, users=users)
+                return render_template("tasks/edit.html", task=task, projects=projects, users=users, kanban_columns=KanbanColumn.get_columns_with_global_fallback(project_id=task.project_id))
 
         # Update task
         # Handle project change first so any early returns (status flows) still persist it
@@ -524,7 +529,7 @@ def edit_task(task_id):
                             flash(
                                 _("Could not update status due to a database error. Please check server logs."), "error"
                             )
-                        return render_template("tasks/edit.html", task=task, projects=projects, users=users)
+                        return render_template("tasks/edit.html", task=task, projects=projects, users=users, kanban_columns=KanbanColumn.get_columns_with_global_fallback(project_id=task.project_id))
                     else:
                         task.start_task()
                         db.session.add(
@@ -576,17 +581,17 @@ def edit_task(task_id):
                     )
                     if not safe_commit("edit_task_status_change", {"task_id": task.id, "status": selected_status}):
                         flash("Could not update status due to a database error. Please check server logs.", "error")
-                        return render_template("tasks/edit.html", task=task, projects=projects, users=users)
+                        return render_template("tasks/edit.html", task=task, projects=projects, users=users, kanban_columns=KanbanColumn.get_columns_with_global_fallback(project_id=task.project_id))
             except ValueError as e:
                 flash(str(e), "error")
-                return render_template("tasks/edit.html", task=task, projects=projects, users=users)
+                return render_template("tasks/edit.html", task=task, projects=projects, users=users, kanban_columns=KanbanColumn.get_columns_with_global_fallback(project_id=task.project_id))
 
         # Always update the updated_at timestamp to local time after edits
         task.updated_at = now_in_app_timezone()
 
         if not safe_commit("edit_task", {"task_id": task.id}):
             flash(_("Could not update task due to a database error. Please check server logs."), "error")
-            return render_template("tasks/edit.html", task=task, projects=projects, users=users)
+            return render_template("tasks/edit.html", task=task, projects=projects, users=users, kanban_columns=KanbanColumn.get_columns_with_global_fallback(project_id=task.project_id))
 
         # Log task update
         app_module.log_event("task.updated", user_id=current_user.id, task_id=task.id, project_id=task.project_id)
@@ -611,7 +616,7 @@ def edit_task(task_id):
     projects = Project.query.filter_by(status="active").order_by(Project.name).all()
     users = User.query.order_by(User.username).all()
 
-    return render_template("tasks/edit.html", task=task, projects=projects, users=users)
+    return render_template("tasks/edit.html", task=task, projects=projects, users=users, kanban_columns=KanbanColumn.get_columns_with_global_fallback(project_id=task.project_id))
 
 
 @tasks_bp.route("/tasks/<int:task_id>/status", methods=["POST"])

--- a/app/routes/team_chat.py
+++ b/app/routes/team_chat.py
@@ -467,7 +467,7 @@ def upload_attachment(channel_id):
         "csv",
         "json",
     }
-    UPLOAD_FOLDER = "uploads/chat_attachments"
+    UPLOAD_FOLDER = "app/static/uploads/chat_attachments"
     MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
 
     def allowed_file(filename):

--- a/app/templates/tasks/create.html
+++ b/app/templates/tasks/create.html
@@ -68,11 +68,9 @@
                                 <label for="status" class="form-label">{{ _('Initial Status') }}</label>
                                 <select id="status" name="status" class="form-input">
                                     {% set initial_status = request.form.get('status') or request.args.get('status') or 'todo' %}
-                                    <option value="todo" {% if initial_status == 'todo' %}selected{% endif %}>{{ _('To Do') }}</option>
-                                    <option value="in_progress" {% if initial_status == 'in_progress' %}selected{% endif %}>{{ _('In Progress') }}</option>
-                                    <option value="review" {% if initial_status == 'review' %}selected{% endif %}>{{ _('Review') }}</option>
-                                    <option value="done" {% if initial_status == 'done' %}selected{% endif %}>{{ _('Done') }}</option>
-                                    <option value="cancelled" {% if initial_status == 'cancelled' %}selected{% endif %}>{{ _('Cancelled') }}</option>
+                                    {% for col in kanban_columns %}
+                                    <option value="{{ col.key }}" {% if initial_status == col.key %}selected{% endif %}>{{ _(col.label) }}</option>
+                                    {% endfor %}
                                 </select>
                             </div>
                         </div>

--- a/app/templates/tasks/edit.html
+++ b/app/templates/tasks/edit.html
@@ -77,11 +77,9 @@
                             <div>
                                 <label for="status" class="form-label">{{ _('Status') }}</label>
                                 <select id="status" name="status" class="form-input">
-                                    <option value="todo" {% if task.status == 'todo' %}selected{% endif %}>{{ _('To Do') }}</option>
-                                    <option value="in_progress" {% if task.status == 'in_progress' %}selected{% endif %}>{{ _('In Progress') }}</option>
-                                    <option value="review" {% if task.status == 'review' %}selected{% endif %}>{{ _('Review') }}</option>
-                                    <option value="done" {% if task.status == 'done' %}selected{% endif %}>{{ _('Done') }}</option>
-                                    <option value="cancelled" {% if task.status == 'cancelled' %}selected{% endif %}>{{ _('Cancelled') }}</option>
+                                    {% for col in kanban_columns %}
+                                    <option value="{{ col.key }}" {% if task.status == col.key %}selected{% endif %}>{{ _(col.label) }}</option>
+                                    {% endfor %}
                                 </select>
                             </div>
                         </div>


### PR DESCRIPTION
Two distinct fix sets in one PR, addressing the rest of the codebase for two bug classes already partially covered:

- **path-resolution upload bugs** — same defect as the existing `project_attachments` upload code (writes outside the mounted Docker volume → 500 PermissionError on every upload).
- **validator/UI drift bugs** — same defect class as **#605** (validator filters strictly while the UI renders a broader option set, producing 4xx on actions the UI offered).

> **Note on overlap with #605**: this PR includes the additional `get_columns_with_global_fallback()` helper and the `on_hold` addition to the last-ditch fallback list. If #605 lands first, the `kanban_column.py` diff in this PR shrinks to those two additions only. If this PR lands first, #605 is subsumed and can be closed.

## Phase A — path-resolution upload bugs (5 routes)

Each route joins `current_app.root_path + \".\" + \"uploads/<X>\"`, resolving to `/app/uploads/<X>` on a deployed instance. That path is outside the mounted `app_uploads` volume (which mounts at `/app/app/static/uploads`), so every upload returns 500 with `PermissionError`. The pattern was previously corrected in `invoice_images` and `quote_images` upload routes, but five other routes still use the broken path:

| File:line | UPLOAD_FOLDER before | UPLOAD_FOLDER after |
|---|---|---|
| `app/routes/team_chat.py:470` | `uploads/chat_attachments` | `app/static/uploads/chat_attachments` |
| `app/routes/clients.py:1257` | `uploads/client_attachments` | `app/static/uploads/client_attachments` |
| `app/routes/comments.py:279` | `uploads/comment_attachments` | `app/static/uploads/comment_attachments` |
| `app/routes/quotes.py:1120` | `uploads/quote_attachments` | `app/static/uploads/quote_attachments` |
| `app/routes/client_portal.py:1330, 1347` | `\"uploads\"` (hardcoded download fallback) | `\"app/static/uploads\"` |

Repro for any of them: with the standard `app_uploads` volume mount, attempt an upload through the relevant UI → 500 PermissionError on `/app/uploads/<X>`.

## Phase B — validator / UI drift bugs

### `app/models/kanban_column.py`
- New `get_columns_with_global_fallback()` classmethod: returns project-specific columns if they exist, otherwise globals. Mirrors the `get_valid_status_keys` behaviour for templates that need column objects rather than just keys.
- Last-ditch hardcoded fallback in `get_valid_status_keys` now includes `on_hold` so the table-not-yet-seeded path matches the keys `initialize_default_columns` seeds.

### `app/routes/tasks.py`
- `task_counts` dict (line 141) now initialises from `kanban_columns` instead of hardcoding `[\"todo\",\"in_progress\",\"review\",\"done\"]`. Tasks in `cancelled`/`on_hold`/custom columns are counted in summary cards.
- Create-task validator (line 219) now calls `KanbanColumn.get_valid_status_keys(project_id)` instead of a hardcoded 5-key tuple. Creating a task with status `on_hold` no longer silently gets clamped to `todo`.
- Every `render_template(\"tasks/create.html\", ...)` and `(\"tasks/edit.html\", ...)` now passes `kanban_columns` so the templates can render the configured columns.

### `app/templates/tasks/create.html` and `tasks/edit.html`
- Status `<option>` list now loops over `kanban_columns` instead of hardcoding 5 keys. Custom columns added via the kanban admin UI now appear in both forms.

### `app/routes/invoices.py:832`
- Bulk-update status validator now accepts `\"issued\"`, mirroring the single-update validator at line 623; the `Invoice` model supports it (\`status\` may be `'draft', 'issued', 'sent', 'paid', 'overdue', 'cancelled'`). Bulk-marking invoices as `issued` previously hit `Invalid status value`.

### `app/routes/quotes.py` (3 spots: 920, 1026, 1320)
- Admin-notification queries now use `User.is_admin` (which considers both the legacy `role` column AND `Role` rows) instead of `User.query.filter_by(role=\"admin\", ...)`. RBAC-only admins (granted via the `Role` table) are now notified on `quote.sent`, `quote.accepted`, and `quote.approval.requested`.

## Diff size

```
10 files changed, ~60 insertions, ~41 deletions
```

No schema change. No data migration. No new dependencies.

## Test plan

- Drag a task to On Hold from any kanban view → 200 (not 400).
- Create a task with initial status `on_hold` → persists, doesn't silently fall back to `todo`.
- Upload through chat / client / comment / quote routes → 200 (not 500 PermissionError).
- Bulk-mark invoices as Issued → succeeds.
- Send a quote → RBAC `super_admin`/`admin` users (without legacy `role=\"admin\"`) receive notification email.
- Task list summary cards show counts for all configured columns including `on_hold` and `cancelled`.

Tested against `v5.5.2`.