### PR TITLE
fix(tasks): service-layer status validator + preview JS now kanban-aware (companion to #606)

### DIFF
--- a/app/services/task_service.py
+++ b/app/services/task_service.py
@@ -43,7 +43,10 @@ class TaskService:
         self.task_repo = TaskRepository()
         self.project_repo = ProjectRepository()
 
-    VALID_STATUSES = ("todo", "in_progress", "review", "done", "cancelled")
+    # Last-ditch fallback — only used if KanbanColumn lookup fails.
+    # The real validation happens via KanbanColumn.get_valid_status_keys(project_id=...)
+    # so users with custom kanban columns (e.g. on_hold) aren't silently coerced to todo.
+    VALID_STATUSES = ("todo", "in_progress", "review", "done", "on_hold", "cancelled")
 
     def create_task(
         self,
@@ -82,7 +85,16 @@ class TaskService:
         if not project:
             return {"success": False, "message": "Invalid project", "error": "invalid_project"}
 
-        task_status = status if status and status in self.VALID_STATUSES else TaskStatus.TODO.value
+        # Validate status against the configured kanban columns for this project.
+        # Falls back to the hardcoded VALID_STATUSES tuple if KanbanColumn is unavailable
+        # (e.g. table not yet seeded during a fresh migration).
+        try:
+            from app.models import KanbanColumn
+
+            allowed = set(KanbanColumn.get_valid_status_keys(project_id=project_id) or self.VALID_STATUSES)
+        except Exception:
+            allowed = set(self.VALID_STATUSES)
+        task_status = status if status and status in allowed else TaskStatus.TODO.value
 
         # Create task
         task = self.task_repo.create(

--- a/app/templates/tasks/create.html
+++ b/app/templates/tasks/create.html
@@ -68,11 +68,9 @@
                                 <label for="status" class="form-label">{{ _('Initial Status') }}</label>
                                 <select id="status" name="status" class="form-input">
                                     {% set initial_status = request.form.get('status') or request.args.get('status') or 'todo' %}
-                                    <option value="todo" {% if initial_status == 'todo' %}selected{% endif %}>{{ _('To Do') }}</option>
-                                    <option value="in_progress" {% if initial_status == 'in_progress' %}selected{% endif %}>{{ _('In Progress') }}</option>
-                                    <option value="review" {% if initial_status == 'review' %}selected{% endif %}>{{ _('Review') }}</option>
-                                    <option value="done" {% if initial_status == 'done' %}selected{% endif %}>{{ _('Done') }}</option>
-                                    <option value="cancelled" {% if initial_status == 'cancelled' %}selected{% endif %}>{{ _('Cancelled') }}</option>
+                                    {% for col in kanban_columns %}
+                                    <option value="{{ col.key }}" {% if initial_status == col.key %}selected{% endif %}>{{ _(col.label) }}</option>
+                                    {% endfor %}
                                 </select>
                             </div>
                         </div>
@@ -83,7 +81,11 @@
                             </span>
                             <span id="statusPreview" class="status-badge status-{{ request.form.get('status') or request.args.get('status') or 'todo' }}">
                                 {% set status_preview = request.form.get('status') or request.args.get('status') or 'todo' %}
-                                {% if status_preview == 'in_progress' %}{{ _('In Progress') }}{% elif status_preview == 'review' %}{{ _('Review') }}{% elif status_preview == 'done' %}{{ _('Done') }}{% elif status_preview == 'cancelled' %}{{ _('Cancelled') }}{% else %}{{ _('To Do') }}{% endif %}
+                                {%- set _matched = namespace(label=None) -%}
+                                {%- for col in kanban_columns -%}
+                                  {%- if col.key == status_preview -%}{%- set _matched.label = col.label -%}{%- endif -%}
+                                {%- endfor -%}
+                                {{ _(_matched.label) if _matched.label else _('To Do') }}
                             </span>
                         </div>
 
@@ -472,11 +474,9 @@ document.addEventListener('DOMContentLoaded', function() {
             high: { text: '{{ _('High') }}', class: 'priority-high' },
             urgent: { text: '{{ _('Urgent') }}', class: 'priority-urgent' },
         } : {
-            todo: { text: '{{ _('To Do') }}', class: 'status-todo' },
-            in_progress: { text: '{{ _('In Progress') }}', class: 'status-in_progress' },
-            review: { text: '{{ _('Review') }}', class: 'status-review' },
-            done: { text: '{{ _('Done') }}', class: 'status-done' },
-            cancelled: { text: '{{ _('Cancelled') }}', class: 'status-cancelled' },
+            {%- for col in kanban_columns %}
+            {{ col.key }}: { text: '{{ _(col.label) }}', class: 'status-{{ col.key }}' },
+            {%- endfor %}
         };
         const def = map[value] || Object.values(map)[0];
         // Reset classes preserving base class

--- a/app/templates/tasks/edit.html
+++ b/app/templates/tasks/edit.html
@@ -77,11 +77,9 @@
                             <div>
                                 <label for="status" class="form-label">{{ _('Status') }}</label>
                                 <select id="status" name="status" class="form-input">
-                                    <option value="todo" {% if task.status == 'todo' %}selected{% endif %}>{{ _('To Do') }}</option>
-                                    <option value="in_progress" {% if task.status == 'in_progress' %}selected{% endif %}>{{ _('In Progress') }}</option>
-                                    <option value="review" {% if task.status == 'review' %}selected{% endif %}>{{ _('Review') }}</option>
-                                    <option value="done" {% if task.status == 'done' %}selected{% endif %}>{{ _('Done') }}</option>
-                                    <option value="cancelled" {% if task.status == 'cancelled' %}selected{% endif %}>{{ _('Cancelled') }}</option>
+                                    {% for col in kanban_columns %}
+                                    <option value="{{ col.key }}" {% if task.status == col.key %}selected{% endif %}>{{ _(col.label) }}</option>
+                                    {% endfor %}
                                 </select>
                             </div>
                         </div>
@@ -652,11 +650,9 @@ document.addEventListener('DOMContentLoaded', function() {
             high: { text: '{{ _('High') }}', class: 'priority-high' },
             urgent: { text: '{{ _('Urgent') }}', class: 'priority-urgent' },
         } : {
-            todo: { text: '{{ _('To Do') }}', class: 'status-todo' },
-            in_progress: { text: '{{ _('In Progress') }}', class: 'status-in_progress' },
-            review: { text: '{{ _('Review') }}', class: 'status-review' },
-            done: { text: '{{ _('Done') }}', class: 'status-done' },
-            cancelled: { text: '{{ _('Cancelled') }}', class: 'status-cancelled' },
+            {%- for col in kanban_columns %}
+            {{ col.key }}: { text: '{{ _(col.label) }}', class: 'status-{{ col.key }}' },
+            {%- endfor %}
         };
         const def = map[value] || Object.values(map)[0];
         element.className = element.className.split(' ').filter(c => !c.startsWith(type === 'priority' ? 'priority-' : 'status-')).join(' ').trim();


### PR DESCRIPTION
Companion to **#606**. The route validator at `tasks.py:223` already calls `KanbanColumn.get_valid_status_keys()`, but two downstream spots still silently re-introduce the old hardcoded 5-key behaviour. This PR closes both gaps.

## Bug

Creating a task with an initial status outside the hardcoded 5-key set (e.g. \`on_hold\` from a configured global kanban column) persists the task with `status=\"todo\"`, even though the form correctly submits `on_hold` and the route validator accepts it.

## Repro

1. Configure a global kanban column with key `on_hold` (the `initialize_default_columns` migration seeds this).
2. Open the task create form.
3. In the Initial Status dropdown, select \"On Hold\".
4. Observe: the preview badge shows \"To Do\", not \"On Hold\".
5. Submit the form.
6. Observe: task is persisted with `status=\"todo\"`.

## Root causes

### 1. `app/services/task_service.py:46`

```python
VALID_STATUSES = (\"todo\", \"in_progress\", \"review\", \"done\", \"cancelled\")
```

Class-level hardcoded tuple. `create_task()` at line 85:

```python
task_status = status if status and status in self.VALID_STATUSES else TaskStatus.TODO.value
```

Silent coercion. Same defect class as the route-level fix in #606, but at the service layer.

### 2. `app/templates/tasks/create.html` (server render + JS) and `tasks/edit.html` (JS)

The status preview badge is driven by:

- A Jinja `{% if status_preview == 'todo' %}…{% elif … %}` chain (server render only in create.html)
- A client-side `updateBadge()` JS map keyed on the same hardcoded 5 keys

When the user picks \"On Hold\" in the dropdown:
- `map['on_hold']` → undefined → JS falls back to `Object.values(map)[0]` (\"To Do\").

That's the visible \"the preview shows To Do but I picked On Hold\" symptom.

## Fix

### Service
- `create_task()` now calls `KanbanColumn.get_valid_status_keys(project_id=project_id)` to build the allowed set per call. The `VALID_STATUSES` tuple is kept as a last-ditch fallback for table-not-yet-seeded paths and extended to include `\"on_hold\"` so even the fallback matches `initialize_default_columns`.

### Templates
- The Jinja preview chain in `create.html` now loops over `kanban_columns` to find the matching label.
- The JS `updateBadge()` map in `create.html` and `edit.html` is now generated from `{% for col in kanban_columns %}`, so any configured column key works without further code changes.

## Diff size

```
3 files changed, +25 / -13
```

No schema change, no data migration.

## Test plan

- Create a task with initial status `on_hold` → persists with `status=\"on_hold\"`.
- The form's preview badge updates correctly when the dropdown changes (no \"To Do\" lie).
- The edit form's preview also updates correctly when changing status.
- Existing tasks with custom kanban columns no longer trigger silent coercion in `task_service.create_task()`.

Tested against `v5.5.2`. Companion to #606 — please review in that order.