### PR TITLE
feat(oidc): map OIDC groups to RBAC Role rows on login (additive default)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -104,6 +104,46 @@ class Config:
     OIDC_ADMIN_EMAILS = [e.strip().lower() for e in os.getenv("OIDC_ADMIN_EMAILS", "").split(",") if e.strip()]
     OIDC_POST_LOGOUT_REDIRECT_URI = os.getenv("OIDC_POST_LOGOUT_REDIRECT_URI")
 
+    # OIDC group -> RBAC Role name mapping (JSON object).
+    # Example:
+    #   OIDC_ROLE_GROUP_MAP='{"timetracker-super-admin":"super_admin","timetracker-admin":"admin","timetracker-manager":"manager","timetracker-viewer":"viewer"}'
+    # Empty/invalid JSON disables the feature; the legacy OIDC_ADMIN_GROUP path keeps working.
+    _oidc_role_map_raw = os.getenv("OIDC_ROLE_GROUP_MAP", "").strip()
+    OIDC_ROLE_GROUP_MAP: dict = {}
+    if _oidc_role_map_raw:
+        try:
+            import json as _json
+
+            _parsed = _json.loads(_oidc_role_map_raw)
+            if isinstance(_parsed, dict):
+                # Ensure values are strings (Role names)
+                OIDC_ROLE_GROUP_MAP = {str(k): str(v) for k, v in _parsed.items() if k and v}
+        except Exception:
+            # Defer the warning to first OIDC callback so it lands in the app log,
+            # but don't crash the app. OIDC_ROLE_GROUP_MAP stays {} = no-op.
+            pass
+
+    # Sync mode for OIDC role assignment:
+    #   "additive" (default, safe) — only ADD roles matching groups; never revoke.
+    #   "sync"                     — also REMOVE mapped roles when the group is gone.
+    # Council recommendation: ship additive first, flip to sync only after observing one
+    # full re-login cycle for every active user.
+    OIDC_ROLE_SYNC_MODE = os.getenv("OIDC_ROLE_SYNC_MODE", "additive").strip().lower()
+    if OIDC_ROLE_SYNC_MODE not in ("additive", "sync"):
+        OIDC_ROLE_SYNC_MODE = "additive"
+
+    # Escape hatch: user IDs that must NEVER have roles revoked by OIDC sync,
+    # regardless of OIDC_ROLE_SYNC_MODE. Comma-separated integers.
+    # Strongly recommended for the bootstrap super_admin user (id 1) so a
+    # misconfigured OIDC_ROLE_GROUP_MAP cannot lock you out of your own instance.
+    OIDC_NEVER_REVOKE_USER_IDS: set = set()
+    _never_revoke_raw = os.getenv("OIDC_NEVER_REVOKE_USER_IDS", "").strip()
+    if _never_revoke_raw:
+        for _x in _never_revoke_raw.split(","):
+            _x = _x.strip()
+            if _x.isdigit():
+                OIDC_NEVER_REVOKE_USER_IDS.add(int(_x))
+
     # OIDC metadata fetch configuration (for DNS resolution issues)
     OIDC_METADATA_FETCH_TIMEOUT = int(os.getenv("OIDC_METADATA_FETCH_TIMEOUT", 10))  # seconds
     OIDC_METADATA_RETRY_ATTEMPTS = int(os.getenv("OIDC_METADATA_RETRY_ATTEMPTS", 3))  # number of retries

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1428,6 +1428,69 @@ def oidc_callback():
         except Exception:
             pass
 
+        # OIDC group -> RBAC Role mapping (additive by default).
+        # When OIDC_ROLE_GROUP_MAP is configured, sync user.roles based on the
+        # groups claim. Default mode is "additive" — only adds roles that match
+        # the user's groups; never revokes. To enable revocation of roles
+        # mapped to groups the user no longer belongs to, set
+        # OIDC_ROLE_SYNC_MODE=sync. The OIDC_NEVER_REVOKE_USER_IDS escape
+        # hatch keeps specific user IDs immune to revocation regardless of mode.
+        try:
+            role_map = getattr(Config, "OIDC_ROLE_GROUP_MAP", {}) or {}
+            if role_map and isinstance(groups, (list, tuple)):
+                from app.models import Role
+
+                sync_mode = getattr(Config, "OIDC_ROLE_SYNC_MODE", "additive")
+                never_revoke = getattr(Config, "OIDC_NEVER_REVOKE_USER_IDS", set()) or set()
+
+                # Compute target Role names from the user's groups
+                target_role_names = {role_map[g] for g in groups if g in role_map}
+
+                # Look up Role objects by name (only those that actually exist in DB)
+                target_roles = (
+                    Role.query.filter(Role.name.in_(target_role_names)).all() if target_role_names else []
+                )
+                target_role_set = set(target_roles)
+                current_role_set = set(user.roles)
+                roles_changed = False
+
+                # ADD: any target roles the user doesn't already have
+                for r in target_role_set - current_role_set:
+                    user.roles.append(r)
+                    roles_changed = True
+                    current_app.logger.info(
+                        "OIDC role sync: added role %s to user %s (matched group)", r.name, user.username
+                    )
+
+                # REMOVE: only in sync mode AND only mapped roles (never revoke roles
+                # assigned manually outside OIDC scope) AND only if user not protected.
+                if sync_mode == "sync" and user.id not in never_revoke:
+                    mapped_role_names = set(role_map.values())
+                    for r in current_role_set - target_role_set:
+                        if r.name in mapped_role_names:
+                            user.roles.remove(r)
+                            roles_changed = True
+                            current_app.logger.info(
+                                "OIDC role sync: removed role %s from user %s (no matching group)",
+                                r.name,
+                                user.username,
+                            )
+
+                if roles_changed:
+                    if not safe_commit("oidc_sync_roles", {"user_id": user.id}):
+                        current_app.logger.warning(
+                            "DB commit failed syncing OIDC roles for user_id=%s", user.id
+                        )
+            elif getattr(Config, "_oidc_role_map_raw", None):
+                # User configured the env var but it failed to parse; surface once per login.
+                current_app.logger.warning(
+                    "OIDC_ROLE_GROUP_MAP is set but failed to parse as a JSON object; role sync disabled."
+                )
+        except Exception as e:
+            current_app.logger.exception(
+                "OIDC role sync failed for user_id=%s: %s", getattr(user, "id", None), e
+            )
+
         # Check if user is active
         if not user.is_active:
             current_app.logger.info("OIDC callback redirect to login: reason=user_inactive")


### PR DESCRIPTION
Wires the OIDC groups claim into the RBAC `Role` table introduced by migration `030_add_permission_system.py` (`super_admin`, `admin`, `manager`, `user`, `viewer`).

## Why

Today OIDC can only set the legacy `users.role=\"admin\"` column via `OIDC_ADMIN_GROUP`. Nothing in the codebase ever assigns `Role` rows from OIDC, so an IdP group can grant the binary `is_admin` flag but not `super_admin`, `manager`, `user`, `viewer`, or any custom role created via the Permissions UI.

This adds opt-in OIDC → RBAC group mapping without touching the schema and without changing existing deployments' behaviour.

## What

Three new env vars, all opt-in (default off):

| Var | Type | Default | Purpose |
|---|---|---|---|
| `OIDC_ROLE_GROUP_MAP` | JSON object | `{}` (no-op) | OIDC group name → Role name |
| `OIDC_ROLE_SYNC_MODE` | `additive` \| `sync` | `additive` | Whether to revoke mapped roles when a group is gone |
| `OIDC_NEVER_REVOKE_USER_IDS` | comma-sep ints | empty | User IDs immune to revocation |

Example:

```
OIDC_ROLE_GROUP_MAP='{\"app-super-admin\":\"super_admin\",\"app-admin\":\"admin\",\"app-manager\":\"manager\"}'
OIDC_ROLE_SYNC_MODE=additive
OIDC_NEVER_REVOKE_USER_IDS=1
```

## Behaviour

In `app/routes/auth.py` after the existing `OIDC_ADMIN_GROUP` block, on each OIDC login:

1. Parse the user's groups claim against `OIDC_ROLE_GROUP_MAP` → a set of target Role names.
2. Look up matching `Role` rows in DB (silently skips names that don't exist as Role rows).
3. **ADD**: any target Role the user doesn't already have.
4. **REMOVE** (sync mode only): only Role rows whose name is in the map's values (so manually-assigned roles outside OIDC scope are preserved), and only if the user is **not** in `OIDC_NEVER_REVOKE_USER_IDS`.
5. Commit via `safe_commit`; failures log a warning and continue.

## Defensive parsing

`OIDC_ROLE_GROUP_MAP` parsing in `config.py`:

- empty / missing → `{}` (no-op)
- invalid JSON → `{}` + warning logged on first OIDC callback
- non-dict root (array, null, number, string) → `{}`
- falsy keys/values → filtered out

`OIDC_ROLE_SYNC_MODE` defaults to `additive` for any value that isn't exactly `additive` or `sync` (typos default to safe).

`OIDC_NEVER_REVOKE_USER_IDS` ignores non-integer entries.

## Why additive default

A misconfigured `OIDC_ROLE_GROUP_MAP` JSON in `sync` mode would silently revoke every mapped role on the next login. Defaulting to `additive` makes a misconfigured map degrade to a no-op rather than a potential lockout. `OIDC_NEVER_REVOKE_USER_IDS` is the operator's belt-and-suspenders for the bootstrap super_admin.

## Backward compat

Every existing OIDC deployment without any of these env vars set keeps identical behaviour to before this PR. The pre-existing `OIDC_ADMIN_GROUP` → `users.role=\"admin\"` path is untouched and continues to fire alongside the new group sync.

## Test plan

With `OIDC_ROLE_GROUP_MAP='{\"app-manager\":\"manager\"}'` and `OIDC_NEVER_REVOKE_USER_IDS=1`:

1. **Additive add**: user whose groups include `app-manager` logs in → `manager` Role row appears in `user_roles` after login.
2. **No-op for unmapped**: user with no mapped groups logs in → `user.roles` is unchanged.
3. **Manual roles preserved**: pre-assign a `Role` row to a user that is NOT in the map's values. Log in. That role is preserved (additive never removes; sync only removes mapped names).
4. **Escape hatch**: in `sync` mode, ensure `id=1` keeps roles even when none of their groups maps.
5. **Defensive parse**: set `OIDC_ROLE_GROUP_MAP='garbage{not json'`. App starts; OIDC login still succeeds; one warning is logged on first callback; no role changes.

## Diff size

```
2 files changed, +103 / -0
```

No schema change. No data migration. No new dependencies.

Tested against `v5.5.2`.