### PR TITLE
fix(ui): hide remaining donate widgets on licensed instances (companion to #603)

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1184,7 +1184,7 @@
                             <span class="ml-3 sidebar-label">{{ _('Help') }}</span>
                         </a>
                     </li>
-                    {% if current_user.is_authenticated and current_user.ui_show_donate %}
+                    {% if current_user.is_authenticated and current_user.ui_show_donate and not is_license_activated %}
                     <li class="mt-2">
                         <button type="button" class="sidebar-nav-item w-full text-left flex items-center p-2 rounded-lg bg-gradient-to-r from-amber-500/10 to-orange-500/10 border border-amber-500/20 text-amber-600 dark:text-amber-400 hover:from-amber-500/20 hover:to-orange-500/20 hover:border-amber-500/30 transition-all duration-200 group js-open-support-modal" title="{{ _('Open support options') }}">
                             <i class="fas fa-heart w-6 text-center group-hover:scale-110 transition-transform" aria-hidden="true"></i>
@@ -1260,7 +1260,7 @@
                             <i class="fas fa-wand-magic-sparkles"></i>
                         </button>
                         {% endif %}
-                        {% if current_user.is_authenticated %}
+                        {% if current_user.is_authenticated and not is_license_activated %}
                         <button type="button" id="headerSupportBtn" class="hidden sm:inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-sm font-medium text-amber-800 dark:text-amber-200 bg-amber-500/15 hover:bg-amber-500/25 border border-amber-500/30 dark:border-amber-500/40 focus:outline-none focus:ring-2 focus:ring-amber-500/40" title="{{ _('Support TimeTracker') }}">
                             <i class="fas fa-heart text-amber-600 dark:text-amber-300" aria-hidden="true"></i>
                             <span class="max-w-[10rem] truncate">{{ _('Support TimeTracker') }}</span>
@@ -1325,7 +1325,7 @@
                             {% if current_user.is_authenticated %}
                             <li><a href="{{ url_for('user.license') }}" class="flex items-center gap-2 px-4 py-2 text-sm text-text-light dark:text-text-dark hover:bg-gray-100 dark:hover:bg-gray-700"><i class="fas fa-key w-4"></i> {{ _('License') }}</a></li>
                             {% endif %}
-                            {% if current_user.is_authenticated %}
+                            {% if current_user.is_authenticated and not is_license_activated %}
                             <li><button type="button" class="js-open-support-modal w-full text-left flex flex-col gap-0.5 px-4 py-2 text-sm text-amber-600 dark:text-amber-400 hover:bg-gray-100 dark:hover:bg-gray-700"><span class="font-medium"><i class="fas fa-heart w-4" aria-hidden="true"></i> {{ _('Support TimeTracker') }}</span><span class="text-xs text-text-muted-light dark:text-text-muted-dark">{{ _('Donate or get a supporter license') }}</span></button></li>
                             {% endif %}
                             <li class="border-t border-border-light dark:border-border-dark"><a href="{{ url_for('auth.logout') }}" class="flex items-center gap-2 px-4 py-2 text-sm text-rose-600 dark:text-rose-400 hover:bg-gray-100 dark:hover:bg-gray-700"><i class="fas fa-sign-out-alt w-4"></i> {{ _('Logout') }}</a></li>
@@ -1353,7 +1353,7 @@
                 {% endwith %}
             </div>
 
-            {% if current_user.is_authenticated and current_user.ui_show_donate %}
+            {% if current_user.is_authenticated and current_user.ui_show_donate and not is_license_activated %}
             <!-- Dismissible Support Banner -->
             <div id="supportBanner" class="bg-gradient-to-r from-amber-50 to-orange-50 dark:from-amber-900/20 dark:to-orange-900/20 border-b border-amber-200 dark:border-amber-800 px-4 py-3 opacity-0 invisible max-h-0 overflow-hidden transition-all duration-300 ease-in-out">
                 <div class="max-w-7xl mx-auto flex items-center justify-between gap-4">

--- a/app/templates/main/about.html
+++ b/app/templates/main/about.html
@@ -40,7 +40,7 @@
     </div>
 </div>
 
-{% if current_user.is_authenticated and current_user.ui_show_donate %}
+{% if current_user.is_authenticated and current_user.ui_show_donate and not is_license_activated %}
 <div class="mb-6 sm:mb-8 p-4 sm:p-5 rounded-xl border border-border-light dark:border-border-dark bg-card-light dark:bg-card-dark flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
     <p class="text-sm text-text-light dark:text-text-dark">{{ _('TimeTracker is free and open source. You can donate or buy a supporter license — features are never locked.') }}</p>
     <button type="button" class="btn btn-primary flex-shrink-0 w-full sm:w-auto text-center js-open-support-modal">{{ _('Support TimeTracker') }}</button>

--- a/app/templates/main/dashboard.html
+++ b/app/templates/main/dashboard.html
@@ -626,7 +626,7 @@
         </div>
     </div>
 
-    {% if current_user.ui_show_donate %}
+    {% if current_user.ui_show_donate and not is_license_activated %}
     <div class="bg-card-light dark:bg-card-dark border border-border-light dark:border-border-dark p-5 rounded-xl shadow-sm dashboard-widget">
         <div class="flex items-center gap-2 mb-3">
             <div class="bg-amber-500/10 dark:bg-amber-400/10 p-2 rounded-lg">

--- a/app/templates/main/help.html
+++ b/app/templates/main/help.html
@@ -831,14 +831,14 @@
                 <a href="https://github.com/drytrix/TimeTracker/issues" target="_blank" rel="noopener" class="px-4 py-2 rounded-lg border border-amber-600 text-amber-600 hover:bg-amber-50 dark:hover:bg-amber-900/20">
                     <i class="fas fa-bug mr-1"></i>{{ _('Report Issue') }}
                 </a>
-                {% if current_user.is_authenticated and current_user.ui_show_donate %}
+                {% if current_user.is_authenticated and current_user.ui_show_donate and not is_license_activated %}
                 <button type="button" class="px-4 py-2 rounded-lg bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-600 hover:to-orange-600 text-white font-semibold shadow-md hover:shadow-lg transition-all js-open-support-modal">
                     <i class="fas fa-heart mr-1" aria-hidden="true"></i>{{ _('Support TimeTracker') }}
                 </button>
                 {% endif %}
             </div>
         </div>
-        {% if current_user.is_authenticated and current_user.ui_show_donate %}
+        {% if current_user.is_authenticated and current_user.ui_show_donate and not is_license_activated %}
         <p class="text-sm text-text-muted-light dark:text-text-muted-dark mt-6 pt-4 border-t border-border-light dark:border-border-dark">
             {{ _('Enjoying TimeTracker?') }} {{ _('Donations and licenses fund development; nothing is paywalled.') }}
             <button type="button" class="text-primary hover:underline font-medium js-open-support-modal">{{ _('Open support') }}</button>

--- a/app/templates/reports/index.html
+++ b/app/templates/reports/index.html
@@ -15,7 +15,7 @@
     actions_html=None
 ) }}
 
-{% if current_user.is_authenticated and current_user.ui_show_donate %}
+{% if current_user.is_authenticated and current_user.ui_show_donate and not is_license_activated %}
 <p class="text-sm text-text-muted-light dark:text-text-muted-dark mb-4">
     {{ _('Enjoying TimeTracker?') }} {{ _('Support development or get a supporter license — the app stays free for everyone.') }}
     <button type="button" class="text-primary hover:underline font-medium js-open-support-modal">{{ _('Open support') }}</button>


### PR DESCRIPTION
Companion to **#603**. That earlier PR added `is_license_activated` guards to three donate UI gates (header support button, user-menu support link, support modal donate/buy-license buttons). Six other donate gates in templates were missed and still leak on licensed instances.

> **Note on overlap with #603**: this PR's `app/templates/base.html` diff includes both #603's changes (lines 1263, 1328, support_modal) and this PR's changes (lines 1187, 1356). If #603 lands first, the `base.html` diff in this PR shrinks to the +2/-2 unique to it. If this PR lands first, #603 is subsumed.

## Repro

1. Activate a supporter license (`settings.donate_ui_hidden = true`).
2. Log in as a user whose `users.ui_show_donate` is still its default `true`.
3. Observe — despite the active license — the large amber-gradient banner at the top of every page (`Enjoying TimeTracker? / Support / Get key / Buy Me a Coffee / PayPal`), plus the help-page prompts, dashboard widget, reports-page prompt, about-page header, and sidebar nav entry.

## Affected gates

| File:line | Element | Current guard | Fix |
|---|---|---|---|
| `app/templates/base.html:1187` | sidebar nav donate entry | per-user only | + `not is_license_activated` |
| `app/templates/base.html:1356` | large dismissible support banner | per-user only | + `not is_license_activated` |
| `app/templates/main/help.html:834` | help donate prompt | per-user only | + `not is_license_activated` |
| `app/templates/main/help.html:841` | help donate banner | per-user only | + `not is_license_activated` |
| `app/templates/main/about.html:43` | about-page donate header | per-user only | + `not is_license_activated` |
| `app/templates/main/dashboard.html:629` | dashboard donate widget | per-user only | + `not is_license_activated` |
| `app/templates/reports/index.html:18` | reports-page donate prompt | per-user only | + `not is_license_activated` |

The two `about.html` gates at lines 189 and 196 already check `donate_ui_hidden` (functionally equivalent to `is_license_activated`) and are left untouched.

## Diff size

```
5 files changed, +7 / -7    (this PR alone, against post-#603 main)
5 files changed, +9 / -9    (this branch as-pushed, includes #603 changes too)
```

No backend, schema, or behavioural change beyond the template visibility guard.

## Test plan

After deploy on a licensed instance:

- Reload any page → the banner at the top is gone for every authenticated user, regardless of their `ui_show_donate` value.
- Visit `/dashboard`, `/reports`, `/help`, `/about` → no donate prompts, no donate widgets.
- The legacy paths still work: `OIDC_ADMIN_GROUP`, `is_admin` checks, the donate page itself (`/donate`) still renders for anyone who navigates there directly (no change to that route).

Tested against `v5.5.2`.