### PR TITLE
fix(clients): remove nested script tag that orphaned confirmDeleteNote

### DIFF
--- a/app/templates/clients/view.html
+++ b/app/templates/clients/view.html
@@ -572,7 +572,6 @@ function toggleImportant(noteId, setImportant) {
 }
 
 {% if can_invoice_unbilled_time|default(false) and unbilled_invoice_preview is defined and unbilled_invoice_preview %}
-<script>
 (function () {
   const btn = document.getElementById('client-invoice-unbilled-btn');
   if (!btn || btn.disabled) return;
@@ -622,7 +621,6 @@ function toggleImportant(noteId, setImportant) {
     }
   });
 })();
-</script>
 {% endif %}
 
 async function confirmDeleteNote(noteId) {


### PR DESCRIPTION
## Summary

`app/templates/clients/view.html` has a `<script>` block opened inside
another already-open `<script>` block. The outer notes script starts at
line 534; the conditional invoice-unbilled-time IIFE then wraps itself
in its own `<script>...</script>` at lines 575/625. Browsers don't allow
nested script tags — the inner `</script>` closes the outer one, leaving
`confirmDeleteNote` and the trailing `</script>` (line 642) as raw HTML.

Visible symptom: the source of `confirmDeleteNote` renders as literal
text at the bottom of every client detail page, and the per-note Delete
button silently fails because the function was never registered as JS.

Fix: drop the nested `<script>` and `</script>` tags. The IIFE now lives
inline within the outer script, which is what was intended.

## Test plan

- [ ] Open `/clients/<id>` for any client — no JS source text at the bottom of the page
- [ ] Add a note, then click Delete on it — confirm dialog appears, deletion works
- [ ] Verify the "Invoice unbilled time" button still works on clients that have unbilled time (when `can_invoice_unbilled_time` is true)