### PR TITLE
fix(kanban): include on_hold in last-ditch validator fallback

### DIFF
--- a/app/models/kanban_column.py
+++ b/app/models/kanban_column.py
@@ -9,28 +9,54 @@ class KanbanColumn(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     project_id = db.Column(
-        db.Integer, db.ForeignKey("projects.id", ondelete="CASCADE"), nullable=True, index=True
+        db.Integer,
+        db.ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
     )  # NULL = global columns
-    key = db.Column(db.String(50), nullable=False, index=True)  # Internal identifier (e.g. 'in_progress')
-    label = db.Column(db.String(100), nullable=False)  # Display name (e.g. 'In Progress')
+    key = db.Column(
+        db.String(50), nullable=False, index=True
+    )  # Internal identifier (e.g. 'in_progress')
+    label = db.Column(
+        db.String(100), nullable=False
+    )  # Display name (e.g. 'In Progress')
     icon = db.Column(db.String(100), default="fas fa-circle")  # Font Awesome icon class
-    color = db.Column(db.String(50), default="secondary")  # Bootstrap color class or hex
-    position = db.Column(db.Integer, nullable=False, default=0, index=True)  # Order in kanban board
-    is_active = db.Column(db.Boolean, default=True, nullable=False)  # Can be disabled without deletion
-    is_system = db.Column(db.Boolean, default=False, nullable=False)  # System columns cannot be deleted
-    is_complete_state = db.Column(db.Boolean, default=False, nullable=False)  # Marks task as completed
+    color = db.Column(
+        db.String(50), default="secondary"
+    )  # Bootstrap color class or hex
+    position = db.Column(
+        db.Integer, nullable=False, default=0, index=True
+    )  # Order in kanban board
+    is_active = db.Column(
+        db.Boolean, default=True, nullable=False
+    )  # Can be disabled without deletion
+    is_system = db.Column(
+        db.Boolean, default=False, nullable=False
+    )  # System columns cannot be deleted
+    is_complete_state = db.Column(
+        db.Boolean, default=False, nullable=False
+    )  # Marks task as completed
     created_at = db.Column(db.DateTime, default=now_in_app_timezone, nullable=False)
-    updated_at = db.Column(db.DateTime, default=now_in_app_timezone, onupdate=now_in_app_timezone, nullable=False)
+    updated_at = db.Column(
+        db.DateTime,
+        default=now_in_app_timezone,
+        onupdate=now_in_app_timezone,
+        nullable=False,
+    )
 
     # Unique constraint: key must be unique per project (or globally if project_id is NULL)
-    __table_args__ = (db.UniqueConstraint("key", "project_id", name="uq_kanban_column_key_project"),)
+    __table_args__ = (
+        db.UniqueConstraint("key", "project_id", name="uq_kanban_column_key_project"),
+    )
 
     def __init__(self, **kwargs):
         """Initialize a new KanbanColumn"""
         super(KanbanColumn, self).__init__(**kwargs)
 
     def __repr__(self):
-        project_info = f" project_id={self.project_id}" if self.project_id else " global"
+        project_info = (
+            f" project_id={self.project_id}" if self.project_id else " global"
+        )
         return f"<KanbanColumn {self.key}: {self.label}{project_info}>"
 
     def to_dict(self):
@@ -137,7 +163,9 @@ class KanbanColumn(db.Model):
         if not columns:
             # Last-ditch fallback if even global columns are missing
             # (e.g. table not yet seeded during a fresh migration).
-            return ["todo", "in_progress", "review", "done", "cancelled"]
+            # Keep this aligned with the keys initialize_default_columns seeds
+            # plus any well-known optional columns users tend to enable.
+            return ["todo", "in_progress", "review", "done", "on_hold", "cancelled"]
         return [col.key for col in columns]
 
     @classmethod
@@ -213,7 +241,9 @@ class KanbanColumn(db.Model):
             column = cls.query.get(col_id)
             if column:
                 # Verify the column belongs to the correct project
-                if (project_id is None and column.project_id is None) or (column.project_id == project_id):
+                if (project_id is None and column.project_id is None) or (
+                    column.project_id == project_id
+                ):
                     column.position = position
                     column.updated_at = now_in_app_timezone()
 


### PR DESCRIPTION
## Summary

`get_valid_status_keys`'s last-ditch fallback (used when both project-specific
and global columns are missing from the DB) returns a hardcoded list. This
PR adds `on_hold` to that list.

**Up front: `on_hold` is not in `initialize_default_columns`.** It's not a
column the seed creates. The honest framing is: this PR makes the last-ditch
fallback tolerant of `on_hold`, which is one of the most common user-added
custom columns.

## Why it still matters

The fallback only fires when the `kanban_columns` table is empty (fresh
migration, manual table truncate, restore from a partial backup, etc.).
On those paths:

- The seed will run and recreate `todo / in_progress / review / done`.
- But any existing `Task` rows still carry their old `status` values, which
  may include user-added keys like `on_hold` if the install previously had
  those columns enabled.
- A request that lands in the validator window between "table empty" and
  "seed complete" — or any request on an instance where `on_hold` tasks
  exist but the kanban_columns table is somehow empty — comes back as
  400 `Invalid status`.

The function's own docstring already calls this scenario out:

```python
# drops to globally-defined columns like "on_hold" come back as 400
# "Invalid status".
```

The broader fix in #605 made the validator fall back to global columns
first, which handles the common case. This PR closes the corner where
even global columns are missing for a moment, by acknowledging `on_hold`
as a widely-adopted user-added column rather than a strict defaults match.

## What this PR is NOT claiming

- It is **not** changing what `initialize_default_columns` seeds. The
  default seed remains `todo / in_progress / review / done`.
- It is **not** asserting `on_hold` is part of the official default set.
  It's adding it to the fallback list as a tolerance measure.

A maintainer could reasonably decline this on the grounds of "the
fallback should match the seed exactly." That's a defensible stance.
This PR takes the alternative stance: be tolerant of the very common
user-added column so installs with `on_hold` tasks don't 400 in the
narrow window where both kanban_columns sources are empty.

## Diff

```python
return ["todo", "in_progress", "review", "done", "on_hold", "cancelled"]
```

The auto-lint hook reformatted some surrounding column declarations;
the only behavioral change is the addition of `on_hold` to the fallback
list.

## Test plan

- [ ] On an instance where the kanban_columns table is temporarily empty AND existing tasks carry `status='on_hold'`, hit a task move endpoint — should return 200 instead of 400 `Invalid status`
- [ ] After seed completes, behavior is unchanged (real columns from DB take precedence over the fallback)
- [ ] On an instance that has never had `on_hold`, no behavior change either way