### PR TITLE
fix(ui): close orphan div tags breaking task edit/create layout

### DIFF
--- a/app/templates/tasks/create.html
+++ b/app/templates/tasks/create.html
@@ -189,7 +189,6 @@
             </div>
         </div>
     </div>
-</div>
 
 <style>
 /* Priority Badges */

--- a/app/templates/tasks/edit.html
+++ b/app/templates/tasks/edit.html
@@ -336,7 +336,6 @@
             </div>
         </div>
     </div>
-</div>
 
 <style>
 /* Priority Badges */


### PR DESCRIPTION
## Summary

Same class as #610 (projects/list.html and weekly_goals/index.html
orphan-div fix merged into v5.5.3). Both task templates have a stray
`</div>` immediately before the `<style>` block with no matching opener:

- `app/templates/tasks/edit.html:339`
- `app/templates/tasks/create.html:192`

The orphan close pushes the rest of the page outside the outer
`.grid lg:grid-cols-3` wrapper, so the form and sidebar render
left-aligned and the standard footer floats up to the top right.

Structure on both files:

```
L18/19  <div class="grid grid-cols-1 lg:grid-cols-3">  <- outer grid
L19/20    <div class="lg:col-span-2">                   <- left col
            ... form ...
          </div>                                        <- close left col
L148/153  <div class="lg:col-span-1">                   <- right col
            ... sidebar ...
          </div>                                        <- close right col
        </div>                                          <- close outer grid
        </div>                                          <- ORPHAN
```

Verified by a div-balance trace: deleting the orphan brings both files
to final balance 0 with no negative excursions.

## Test plan

- [ ] `/tasks/<id>/edit` — page renders centered, sidebar to the right of the form, footer at bottom
- [ ] `/tasks/new` — same
- [ ] Inline status preview, priority preview, color picker, date pickers all still work (no JS regressions)