### PR TITLE
fix(markdown): unescape Toast UI Editor output and render strikethrough

### DIFF
--- a/app/utils/template_filters.py
+++ b/app/utils/template_filters.py
@@ -1,12 +1,9 @@
-from flask import Blueprint
-
 from app.utils.timezone import (
     format_local_datetime,
     format_user_datetime,
     get_user_date_format,
     get_user_datetime_format,
     get_user_time_format,
-    utc_to_local,
 )
 
 try:
@@ -15,6 +12,38 @@ try:
 except Exception:
     _md = None
     bleach = None
+
+
+# Punctuation chars Python's `markdown` library recognizes as valid backslash
+# escapes. CommonMark allows escaping any ASCII punctuation, but Python
+# markdown only honors this subset. Anything outside it (e.g. `\,`, `\:`)
+# leaks through to the rendered HTML as a literal backslash + char.
+_PYMD_ESCAPABLE = r"\\`*_{}()\[\]#+\-.!"
+
+
+def _normalize_toastui_markdown(text):
+    """Clean up artefacts of Toast UI Editor's WYSIWYG-to-markdown conversion.
+
+    Toast UI follows CommonMark and over-escapes punctuation when round-
+    tripping rich text through its editor. Two patterns matter for display:
+
+    1. Line-leading ``\\- `` (also ``\\* ``, ``\\+ ``) prevents Python markdown
+       from parsing the line as a list item. Toast UI emits this when the
+       user inserts a bullet via WYSIWYG, so unescaping restores the list.
+    2. Backslash-escaped punctuation Python markdown does not recognize
+       (commas, colons, semicolons, etc.) renders as a literal ``\\,`` in
+       the HTML output. Stripping the backslash is safe because none of
+       those chars carry markdown meaning anywhere in a paragraph.
+    """
+    import re
+
+    if not text:
+        return text
+    # Restore line-leading bullets that Toast UI escaped.
+    text = re.sub(r"^(\s*)\\([\-+*])(\s)", r"\1\2\3", text, flags=re.MULTILINE)
+    # Drop backslashes before punctuation Python markdown does not handle.
+    text = re.sub(r"\\([^" + _PYMD_ESCAPABLE + r"])", r"\1", text)
+    return text
 
 
 def register_template_filters(app):
@@ -198,7 +227,9 @@ def register_template_filters(app):
                 "th": ["style", "class", "id"],
                 "td": ["style", "class", "id"],
             }
-            return bleach.clean(text, tags=allowed_tags, attributes=allowed_attrs, strip=True)
+            return bleach.clean(
+                text, tags=allowed_tags, attributes=allowed_attrs, strip=True
+            )
 
         # Process as markdown
         if _md is None:
@@ -209,8 +240,17 @@ def register_template_filters(app):
                 return text
             return escape(text).replace("\n", "<br>")
 
+        # Toast UI Editor (used on the task/note edit pages) over-escapes
+        # punctuation when serialising WYSIWYG content back to markdown.
+        # Strip the escapes Python markdown can't honour so the rendered
+        # output isn't peppered with literal backslashes and so escaped
+        # bullets render as real list items.
+        text = _normalize_toastui_markdown(text)
+
         # Convert markdown to HTML
-        html = _md.markdown(text, extensions=["extra", "sane_lists", "smarty", "codehilite"])
+        html = _md.markdown(
+            text, extensions=["extra", "sane_lists", "smarty", "codehilite"]
+        )
         if bleach is None:
             return html
 
@@ -290,7 +330,9 @@ def register_template_filters(app):
             "th": ["style", "class", "id"],
             "td": ["style", "class", "id"],
         }
-        return bleach.clean(html, tags=allowed_tags, attributes=allowed_attrs, strip=True)
+        return bleach.clean(
+            html, tags=allowed_tags, attributes=allowed_attrs, strip=True
+        )
 
     # Additional filters for PDFs / i18n-friendly formatting
     import datetime
@@ -363,7 +405,9 @@ def register_template_filters(app):
             "AED": "د.إ",
             "SAR": "﷼",
         }
-        symbol = currency_symbols.get((currency_code or "").upper(), currency_code or "EUR")
+        symbol = currency_symbols.get(
+            (currency_code or "").upper(), currency_code or "EUR"
+        )
         return f"{symbol} {num_str}"
 
     @app.template_filter("timeago")

--- a/app/utils/template_filters.py
+++ b/app/utils/template_filters.py
@@ -234,9 +234,7 @@ def register_template_filters(app):
                 "th": ["style", "class", "id"],
                 "td": ["style", "class", "id"],
             }
-            return bleach.clean(
-                text, tags=allowed_tags, attributes=allowed_attrs, strip=True
-            )
+            return bleach.clean(text, tags=allowed_tags, attributes=allowed_attrs, strip=True)
 
         # Process as markdown
         if _md is None:
@@ -255,9 +253,7 @@ def register_template_filters(app):
         text = _normalize_toastui_markdown(text)
 
         # Convert markdown to HTML
-        html = _md.markdown(
-            text, extensions=["extra", "sane_lists", "smarty", "codehilite"]
-        )
+        html = _md.markdown(text, extensions=["extra", "sane_lists", "smarty", "codehilite"])
         if bleach is None:
             return html
 
@@ -337,9 +333,7 @@ def register_template_filters(app):
             "th": ["style", "class", "id"],
             "td": ["style", "class", "id"],
         }
-        return bleach.clean(
-            html, tags=allowed_tags, attributes=allowed_attrs, strip=True
-        )
+        return bleach.clean(html, tags=allowed_tags, attributes=allowed_attrs, strip=True)
 
     # Additional filters for PDFs / i18n-friendly formatting
     import datetime
@@ -412,9 +406,7 @@ def register_template_filters(app):
             "AED": "د.إ",
             "SAR": "﷼",
         }
-        symbol = currency_symbols.get(
-            (currency_code or "").upper(), currency_code or "EUR"
-        )
+        symbol = currency_symbols.get((currency_code or "").upper(), currency_code or "EUR")
         return f"{symbol} {num_str}"
 
     @app.template_filter("timeago")

--- a/app/utils/template_filters.py
+++ b/app/utils/template_filters.py
@@ -25,7 +25,7 @@ def _normalize_toastui_markdown(text):
     """Clean up artefacts of Toast UI Editor's WYSIWYG-to-markdown conversion.
 
     Toast UI follows CommonMark and over-escapes punctuation when round-
-    tripping rich text through its editor. Two patterns matter for display:
+    tripping rich text through its editor. Three patterns matter for display:
 
     1. Line-leading ``\\- `` (also ``\\* ``, ``\\+ ``) prevents Python markdown
        from parsing the line as a list item. Toast UI emits this when the
@@ -34,6 +34,10 @@ def _normalize_toastui_markdown(text):
        (commas, colons, semicolons, etc.) renders as a literal ``\\,`` in
        the HTML output. Stripping the backslash is safe because none of
        those chars carry markdown meaning anywhere in a paragraph.
+    3. ``~~text~~`` strikethrough is part of CommonMark/GFM but the Python
+       ``markdown`` library's ``extra`` extension does not implement it,
+       so it leaks through as literal ``~~...~~`` text. Convert to inline
+       ``<del>`` HTML, which markdown passes through and bleach allows.
     """
     import re
 
@@ -43,6 +47,9 @@ def _normalize_toastui_markdown(text):
     text = re.sub(r"^(\s*)\\([\-+*])(\s)", r"\1\2\3", text, flags=re.MULTILINE)
     # Drop backslashes before punctuation Python markdown does not handle.
     text = re.sub(r"\\([^" + _PYMD_ESCAPABLE + r"])", r"\1", text)
+    # Convert ~~strikethrough~~ to <del>...</del>. Non-greedy and same-line
+    # only so multiple strikethroughs on one line each get their own pair.
+    text = re.sub(r"~~(.+?)~~", r"<del>\1</del>", text)
     return text
 
 


### PR DESCRIPTION
## Summary

Two related rendering bugs in the Jinja `markdown` filter applied to
task and note descriptions. Both stem from the same root cause: the
Toast UI WYSIWYG editor speaks CommonMark, but Python `markdown` does
not implement all of CommonMark.

### Bug 1: backslash-escapes leaking through

Toast UI over-escapes punctuation when serialising WYSIWYG content
back to markdown. Python `markdown` either does not honor those
escapes (`\,` → literal `\,` in the rendered HTML) or honors them in
a way that breaks rendering (line-leading `\-` prevents list parsing).

Sample DB content from a real task:

```
\- VPP/App Store apps: iMovie\, Keynote\, Pages\, Numbers\, TestFlight
\- Adobe Creative Cloud suite \(Acrobat\, Lightroom\, etc\.\)
~~\- 1Password \(standalone \+ Safari extension\)~~
```

Rendered output before fix: bullet lists collapsed into a single flat
paragraph with literal backslashes peppered between words.

### Bug 2: strikethrough not rendering

`~~text~~` is part of CommonMark and GFM, and Toast UI emits it when
the user toggles strikethrough in the WYSIWYG editor. Python markdown's
`extra` extension does not implement strikethrough, so the wrapping
tildes leaked through to the rendered HTML.

## Fix

Add a `_normalize_toastui_markdown` pass before `_md.markdown(...)` in
the `markdown` filter that:

1. Restores line-leading bullets the editor escaped (`\-`, `\*`, `\+`
   followed by whitespace at start of line) so list rendering works.
2. Strips backslashes before punctuation Python markdown does not
   recognise as a valid escape (commas, colons, semicolons, etc.) so
   they don't render as a literal backslash + char.
3. Converts `~~text~~` to `<del>text</del>` inline HTML, which markdown
   passes through and bleach already permits via the existing
   `allowed_tags` list.

The normaliser leaves alone backslashes before punctuation Python
markdown *does* handle natively (`\.`, `\(`, `\)`, `\+`, `\-` mid-line,
`\*`, `\_`, `\#`, etc.) so author-intent escapes still render correctly.

This handles existing rows in the DB without any data migration.

Verified end-to-end against real DB content:

- Bullet lists render as a real `<ul>`/`<li>`
- Inline `\,` strips to `,`
- `\(` `\)` `\+` `\.` render as literal chars (Python markdown handles them)
- `~~struck~~` renders as `<del>struck</del>`
- Multiple strikethroughs on one line each render independently
- Strikethrough combined with bullets (`- ~~item~~`) works

## Test plan

- [ ] Open `/tasks/<id>` for a task authored via the WYSIWYG editor — bullets render as a list, no literal backslashes appear, strikethrough renders as struck-through text
- [ ] Edit a description with intentional escapes (e.g. `\*literal asterisk\*`) — escape still works
- [ ] Render an HTML-style description (`<p>...`) — code path unchanged