### PR TITLE
fix(test): add missing import pytest to test_ai_helper_gate.py

### DIFF
--- a/tests/test_ai_helper_gate.py
+++ b/tests/test_ai_helper_gate.py
@@ -2,6 +2,8 @@
 
 import json
 
+import pytest
+
 pytestmark = [pytest.mark.integration]
 
 


### PR DESCRIPTION
## Summary

`tests/test_ai_helper_gate.py` (added in v5.5.6) uses
`pytestmark = [pytest.mark.integration]` on line 5 but does not import
pytest at the top of the file:

```python
"""AI helper feature flag: UI and session API when AI_ENABLED is off."""

import json

pytestmark = [pytest.mark.integration]    # ← pytest is not imported
```

This causes pytest collection to fail with:

```
E   NameError: name 'pytest' is not defined
ERROR tests/test_ai_helper_gate.py - NameError: name 'pytest' is not defined
```

The error fires during collection, before any test in the file (or in
the rest of the suite, depending on how collection errors propagate) can
run, so it surfaces as a CI failure even when AI features are unrelated
to the change being tested.

## Fix

Add `import pytest` after the existing `import json`.

```python
import json

import pytest

pytestmark = [pytest.mark.integration]
```

## Test plan

- [ ] `pytest tests/test_ai_helper_gate.py` collects without `NameError`
- [ ] The two existing tests in the file (`test_dashboard_hides_ai_helper_when_disabled`, `test_dashboard_shows_ai_helper_when_enabled`, etc.) run and either pass or surface their actual assertions instead of a collection error