### PR TITLE
fix(api): repair joinedload calls referencing non-existent relationships

### DIFF
--- a/app/routes/api_v1.py
+++ b/app/routes/api_v1.py
@@ -924,7 +924,7 @@ def update_kanban_column(col_id):
     """
     from sqlalchemy.orm import joinedload
 
-    col = KanbanColumn.query.options(joinedload(KanbanColumn.project)).filter_by(id=col_id).first_or_404()
+    col = KanbanColumn.query.filter_by(id=col_id).first_or_404()
 
     data = request.get_json() or {}
     for field in ("key", "label", "icon", "color", "position", "is_active", "is_complete_state"):
@@ -944,7 +944,7 @@ def delete_kanban_column(col_id):
     """
     from sqlalchemy.orm import joinedload
 
-    col = KanbanColumn.query.options(joinedload(KanbanColumn.project)).filter_by(id=col_id).first_or_404()
+    col = KanbanColumn.query.filter_by(id=col_id).first_or_404()
 
     if col.is_system:
         return jsonify({"error": "Cannot delete system column"}), 400
@@ -987,7 +987,7 @@ def list_saved_filters():
     page = request.args.get("page", 1, type=int)
     per_page = request.args.get("per_page", 50, type=int)
 
-    query = SavedFilter.query.options(joinedload(SavedFilter.user))
+    query = SavedFilter.query
     query = query.filter(SavedFilter.user_id == g.api_user.id)
     query = query.order_by(SavedFilter.created_at.desc())
 
@@ -1016,7 +1016,7 @@ def get_saved_filter(filter_id):
     """
     from sqlalchemy.orm import joinedload
 
-    sf = SavedFilter.query.options(joinedload(SavedFilter.user)).filter_by(id=filter_id).first_or_404()
+    sf = SavedFilter.query.filter_by(id=filter_id).first_or_404()
 
     if sf.user_id != g.api_user.id and not (sf.is_shared or g.api_user.is_admin):
         return forbidden_response("Access denied")
@@ -1059,7 +1059,7 @@ def update_saved_filter(filter_id):
     """
     from sqlalchemy.orm import joinedload
 
-    sf = SavedFilter.query.options(joinedload(SavedFilter.user)).filter_by(id=filter_id).first_or_404()
+    sf = SavedFilter.query.filter_by(id=filter_id).first_or_404()
 
     if sf.user_id != g.api_user.id and not g.api_user.is_admin:
         return forbidden_response("Access denied")
@@ -1082,7 +1082,7 @@ def delete_saved_filter(filter_id):
     """
     from sqlalchemy.orm import joinedload
 
-    sf = SavedFilter.query.options(joinedload(SavedFilter.user)).filter_by(id=filter_id).first_or_404()
+    sf = SavedFilter.query.filter_by(id=filter_id).first_or_404()
 
     if sf.user_id != g.api_user.id and not g.api_user.is_admin:
         return forbidden_response("Access denied")
@@ -1645,7 +1645,7 @@ def list_client_notes(client_id):
     page = request.args.get("page", 1, type=int)
     per_page = request.args.get("per_page", 50, type=int)
 
-    query = ClientNote.query.options(joinedload(ClientNote.client), joinedload(ClientNote.created_by_user))
+    query = ClientNote.query.options(joinedload(ClientNote.client), joinedload(ClientNote.author))
     query = query.filter(ClientNote.client_id == client_id)
     query = query.order_by(ClientNote.is_important.desc(), ClientNote.created_at.desc())
 
@@ -1692,7 +1692,7 @@ def get_client_note(note_id):
     from sqlalchemy.orm import joinedload
 
     note = (
-        ClientNote.query.options(joinedload(ClientNote.client), joinedload(ClientNote.created_by_user))
+        ClientNote.query.options(joinedload(ClientNote.client), joinedload(ClientNote.author))
         .filter_by(id=note_id)
         .first_or_404()
     )
@@ -1709,7 +1709,7 @@ def update_client_note(note_id):
     from sqlalchemy.orm import joinedload
 
     note = (
-        ClientNote.query.options(joinedload(ClientNote.client), joinedload(ClientNote.created_by_user))
+        ClientNote.query.options(joinedload(ClientNote.client), joinedload(ClientNote.author))
         .filter_by(id=note_id)
         .first_or_404()
     )
@@ -1736,7 +1736,7 @@ def delete_client_note(note_id):
     from sqlalchemy.orm import joinedload
 
     note = (
-        ClientNote.query.options(joinedload(ClientNote.client), joinedload(ClientNote.created_by_user))
+        ClientNote.query.options(joinedload(ClientNote.client), joinedload(ClientNote.author))
         .filter_by(id=note_id)
         .first_or_404()
     )


### PR DESCRIPTION
## Summary

Five integration tests fail because three API v1 route groups call
`joinedload()` on relationships the underlying models never define,
producing `AttributeError` → 500 on the first query that touches them.

The three bad references were all introduced in commit `579fc7af`
("extract business logic to service layer", Nov 2025) and have been
quietly broken since. They surfaced only now because the v5.5.6 fixture
refresh started exercising these endpoints more thoroughly. FK
enforcement (also added in v5.5.6) is a red herring here.

## Repairs

| Model | Bad reference | Fix |
|---|---|---|
| `KanbanColumn` | `KanbanColumn.project` | No `project` relationship exists (only `project_id` FK column); `to_dict()` never reads `self.project`. Drop the dead eager load. |
| `ClientNote` | `ClientNote.created_by_user` | Real relationship is `author`; `to_dict()` reads `self.author.username` / `self.author.full_name`. Rename to the real attribute. |
| `SavedFilter` | `SavedFilter.user` | No `user` relationship exists (only `user_id` FK column); `to_dict()` never reads `self.user`. Drop the dead eager load. |

### Bad call sites (all in `app/routes/api_v1.py`)

- `update_kanban_column` (line 927)
- `delete_kanban_column` (line 947)
- `list_saved_filters` (line 990)
- `get_saved_filter` (line 1019)
- `update_saved_filter` (line 1062)
- `delete_saved_filter` (line 1085)
- `list_client_notes` (line 1648)
- `get_client_note` (line 1695)
- `update_client_note` (line 1712)
- `delete_client_note` (line 1739)

## Tests fixed

- `tests/test_api_kanban_v1.py::test_kanban_columns`
- `tests/test_api_client_notes_v1.py::test_client_notes_crud`
- `tests/test_api_saved_filters_v1.py::test_saved_filters_crud`
- `tests/test_routes/test_api_v1_invoices_tasks_expenses_refactored.py::TestAPITasksRefactored::test_get_task_uses_eager_loading` (transitively, via the same route module)

## Notes

- The unused `from sqlalchemy.orm import joinedload` imports inside the
  kanban / saved-filter handlers are left in place to keep this PR
  surgical (10 lines changed). A follow-up nit-cleanup can prune them.
- Alternative considered for SavedFilter / KanbanColumn: add the real
  relationship to the model. Rejected because `to_dict()` doesn't read
  the attribute anywhere, so the eager load is genuinely dead code and
  the relationship would be unused too.

## Test plan

- [ ] `pytest tests/test_api_kanban_v1.py::test_kanban_columns`
- [ ] `pytest tests/test_api_client_notes_v1.py::test_client_notes_crud`
- [ ] `pytest tests/test_api_saved_filters_v1.py::test_saved_filters_crud`
- [ ] All three return 200 from CRUD operations; no `AttributeError` logged
- [ ] No regression on routes that already used `joinedload` correctly (e.g. `ClientNote.client`, `CalendarEvent.user`)