### PR TITLE
fix(test): refresh stale integration tests after connector refactors

### DIFF
--- a/tests/test_custom_field_definitions.py
+++ b/tests/test_custom_field_definitions.py
@@ -4,8 +4,7 @@ Tests model creation, deletion, and client field cleanup.
 """
 
 import pytest
-from datetime import datetime
-from app.models import CustomFieldDefinition, Client, User
+from app.models import CustomFieldDefinition, Client
 from app import db
 
 
@@ -164,7 +163,9 @@ def test_count_clients_with_value_ignores_other_fields(app, admin_user, test_cli
 
 @pytest.mark.integration
 @pytest.mark.database
-def test_delete_custom_field_removes_from_clients(app, admin_user, test_client, admin_authenticated_client):
+def test_delete_custom_field_removes_from_clients(
+    app, admin_user, test_client, admin_authenticated_client
+):
     """Test that deleting a custom field definition removes it from all clients."""
     with app.app_context():
         # Create custom field definition
@@ -203,7 +204,9 @@ def test_delete_custom_field_removes_from_clients(app, admin_user, test_client, 
 
 @pytest.mark.integration
 @pytest.mark.database
-def test_delete_custom_field_multiple_clients(app, admin_user, test_client, admin_authenticated_client):
+def test_delete_custom_field_multiple_clients(
+    app, admin_user, test_client, admin_authenticated_client
+):
     """Test that deleting a custom field removes it from multiple clients."""
     with app.app_context():
         # Create custom field definition
@@ -245,7 +248,9 @@ def test_delete_custom_field_multiple_clients(app, admin_user, test_client, admi
 
 @pytest.mark.integration
 @pytest.mark.database
-def test_delete_custom_field_no_clients_affected(app, admin_user, admin_authenticated_client):
+def test_delete_custom_field_no_clients_affected(
+    app, admin_user, admin_authenticated_client
+):
     """Test deleting a custom field when no clients have values."""
     with app.app_context():
         # Create custom field definition
@@ -272,7 +277,9 @@ def test_delete_custom_field_no_clients_affected(app, admin_user, admin_authenti
 
 @pytest.mark.integration
 @pytest.mark.database
-def test_delete_custom_field_preserves_other_fields(app, admin_user, test_client, admin_authenticated_client):
+def test_delete_custom_field_preserves_other_fields(
+    app, admin_user, test_client, admin_authenticated_client
+):
     """Test that deleting one custom field doesn't affect other custom fields."""
     with app.app_context():
         # Create two custom field definitions
@@ -289,9 +296,13 @@ def test_delete_custom_field_preserves_other_fields(app, admin_user, test_client
         db.session.add_all([definition1, definition2])
         db.session.commit()
 
-        # Set both fields for client
-        test_client.set_custom_field("field1", "value1")
-        test_client.set_custom_field("field2", "value2")
+        # Set both fields for client. Re-query the client into the current
+        # session so the two JSON mutations are written back through the
+        # active session's identity map; the `test_client` fixture instance
+        # may belong to a different session after the fixture commit.
+        client = Client.query.get(test_client.id)
+        client.set_custom_field("field1", "value1")
+        client.set_custom_field("field2", "value2")
         db.session.commit()
 
         # Delete only definition1
@@ -306,4 +317,3 @@ def test_delete_custom_field_preserves_other_fields(app, admin_user, test_client
         client_after = Client.query.get(test_client.id)
         assert client_after.get_custom_field("field1") is None
         assert client_after.get_custom_field("field2") == "value2"
-

--- a/tests/test_integration/test_activitywatch_integration.py
+++ b/tests/test_integration/test_activitywatch_integration.py
@@ -67,7 +67,7 @@ class TestActivityWatchConnector:
         connector = ActivityWatchConnector(activitywatch_integration, None)
         assert connector.provider_name == "activitywatch"
 
-    @patch("app.integrations.activitywatch.requests.get")
+    @patch("app.integrations.activitywatch.session_request")
     def test_test_connection_success(self, mock_get, activitywatch_integration):
         """Test connection when aw-server returns buckets."""
         mock_resp = Mock()
@@ -83,9 +83,10 @@ class TestActivityWatchConnector:
         assert "Connected to ActivityWatch" in result["message"]
         mock_get.assert_called_once()
         call_args = mock_get.call_args
-        assert "buckets" in call_args[0][0]
+        # session_request signature: (session, method, url, **kw). URL is positional arg 2.
+        assert "buckets" in call_args[0][2]
 
-    @patch("app.integrations.activitywatch.requests.get")
+    @patch("app.integrations.activitywatch.session_request")
     def test_test_connection_failure(self, mock_get, activitywatch_integration):
         """Test connection when aw-server is unreachable."""
         mock_get.side_effect = Exception("Connection refused")
@@ -96,7 +97,7 @@ class TestActivityWatchConnector:
         assert result["success"] is False
         assert "message" in result
 
-    @patch("app.integrations.activitywatch.requests.get")
+    @patch("app.integrations.activitywatch.session_request")
     def test_sync_data_imports_events(self, mock_get, db_session, activitywatch_integration, test_project):
         """Test sync imports ActivityWatch events as time entries."""
         # buckets: dict format
@@ -131,7 +132,7 @@ class TestActivityWatchConnector:
         assert link.time_entry_id == entry.id
         assert "aw-watcher-window_testhost" in link.external_uid
 
-    @patch("app.integrations.activitywatch.requests.get")
+    @patch("app.integrations.activitywatch.session_request")
     def test_sync_data_skips_duplicates(self, mock_get, db_session, activitywatch_integration, test_project):
         """Test sync skips already imported events (idempotency)."""
         ts_raw = "2024-01-15T10:00:00.000000Z"

--- a/tests/test_integration/test_caldav_integration.py
+++ b/tests/test_integration/test_caldav_integration.py
@@ -7,13 +7,23 @@ import pytest
 pytestmark = [pytest.mark.integration]
 
 from datetime import datetime, timedelta, timezone
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 from flask import url_for
 
-from app import db
-from app.models import Integration, IntegrationCredential, IntegrationExternalEventLink, TimeEntry, Project, User
-from app.integrations.caldav_calendar import CalDAVCalendarConnector, CalDAVClient, CalDAVCalendar
-from app.services.integration_service import IntegrationService
+from app.models import (
+    CalendarEvent,
+    Integration,
+    IntegrationCredential,
+    IntegrationExternalEventLink,
+    Project,
+    TimeEntry,
+    User,
+)
+from app.integrations.caldav_calendar import (
+    CalDAVCalendarConnector,
+    CalDAVClient,
+    CalDAVCalendar,
+)
 
 
 @pytest.fixture
@@ -81,7 +91,9 @@ class TestCalDAVClient:
 
     def test_client_initialization(self):
         """Test CalDAV client can be initialized"""
-        client = CalDAVClient(username="user@example.com", password="pass", verify_ssl=True)
+        client = CalDAVClient(
+            username="user@example.com", password="pass", verify_ssl=True
+        )
         assert client.username == "user@example.com"
         assert client.password == "pass"
         assert client.verify_ssl is True
@@ -152,13 +164,17 @@ class TestCalDAVConnector:
 
     def test_provider_name(self, caldav_integration):
         """Test provider name"""
-        credentials = IntegrationCredential.query.filter_by(integration_id=caldav_integration.id).first()
+        credentials = IntegrationCredential.query.filter_by(
+            integration_id=caldav_integration.id
+        ).first()
         connector = CalDAVCalendarConnector(caldav_integration, credentials)
         assert connector.provider_name == "caldav_calendar"
 
     def test_get_basic_creds(self, caldav_integration):
         """Test getting basic credentials"""
-        credentials = IntegrationCredential.query.filter_by(integration_id=caldav_integration.id).first()
+        credentials = IntegrationCredential.query.filter_by(
+            integration_id=caldav_integration.id
+        ).first()
         connector = CalDAVCalendarConnector(caldav_integration, credentials)
         username, password = connector._get_basic_creds()
         assert username == "user@example.com"
@@ -175,12 +191,16 @@ class TestCalDAVConnector:
         """Test connection testing"""
         mock_client = Mock()
         mock_client.discover_calendars.return_value = [
-            CalDAVCalendar(href="https://mail.example.com/dav/Calendar/", name="My Calendar")
+            CalDAVCalendar(
+                href="https://mail.example.com/dav/Calendar/", name="My Calendar"
+            )
         ]
         mock_client.fetch_events.return_value = []
         mock_client_class.return_value = mock_client
 
-        credentials = IntegrationCredential.query.filter_by(integration_id=caldav_integration.id).first()
+        credentials = IntegrationCredential.query.filter_by(
+            integration_id=caldav_integration.id
+        ).first()
         connector = CalDAVCalendarConnector(caldav_integration, credentials)
         result = connector.test_connection()
 
@@ -189,7 +209,9 @@ class TestCalDAVConnector:
         assert len(result["calendars"]) == 1
 
     @patch("app.integrations.caldav_calendar.CalDAVClient")
-    def test_sync_data_imports_events(self, mock_client_class, db_session, caldav_integration, test_project):
+    def test_sync_data_imports_events(
+        self, mock_client_class, db_session, caldav_integration, test_project
+    ):
         """Test syncing imports calendar events as time entries"""
         # Mock calendar event
         now_utc = datetime.now(timezone.utc)
@@ -206,7 +228,9 @@ class TestCalDAVConnector:
         mock_client.fetch_events.return_value = [event_data]
         mock_client_class.return_value = mock_client
 
-        credentials = IntegrationCredential.query.filter_by(integration_id=caldav_integration.id).first()
+        credentials = IntegrationCredential.query.filter_by(
+            integration_id=caldav_integration.id
+        ).first()
         connector = CalDAVCalendarConnector(caldav_integration, credentials)
         result = connector.sync_data()
 
@@ -214,21 +238,20 @@ class TestCalDAVConnector:
         assert result["imported"] == 1
         assert result["skipped"] == 0
 
-        # Verify time entry was created
-        time_entry = TimeEntry.query.filter_by(user_id=caldav_integration.user_id).first()
-        assert time_entry is not None
-        assert time_entry.project_id == test_project.id
-        assert "Meeting with Test Project" in time_entry.notes
-
-        # Verify external event link was created
-        link = IntegrationExternalEventLink.query.filter_by(
-            integration_id=caldav_integration.id, external_uid="test-event-123"
+        # The connector was changed to write CalendarEvent records (not
+        # TimeEntry) and to track imports via a [CalDAV: <uid>] marker in
+        # the description, not an IntegrationExternalEventLink row.
+        calendar_event = CalendarEvent.query.filter_by(
+            user_id=caldav_integration.user_id
         ).first()
-        assert link is not None
-        assert link.time_entry_id == time_entry.id
+        assert calendar_event is not None
+        assert "Meeting with Test Project" in calendar_event.title
+        assert "[CalDAV: test-event-123]" in (calendar_event.description or "")
 
     @patch("app.integrations.caldav_calendar.CalDAVClient")
-    def test_sync_data_skips_duplicates(self, mock_client_class, db_session, caldav_integration, test_project):
+    def test_sync_data_skips_duplicates(
+        self, mock_client_class, db_session, caldav_integration, test_project
+    ):
         """Test sync skips already imported events"""
         # Create existing link
         time_entry = TimeEntry(
@@ -264,7 +287,9 @@ class TestCalDAVConnector:
         mock_client.fetch_events.return_value = [event_data]
         mock_client_class.return_value = mock_client
 
-        credentials = IntegrationCredential.query.filter_by(integration_id=caldav_integration.id).first()
+        credentials = IntegrationCredential.query.filter_by(
+            integration_id=caldav_integration.id
+        ).first()
         connector = CalDAVCalendarConnector(caldav_integration, credentials)
         result = connector.sync_data()
 
@@ -307,13 +332,17 @@ class TestCalDAVRoutes:
         assert response.status_code in (200, 302)
 
         # Verify integration was created
-        integration = Integration.query.filter_by(provider="caldav_calendar", user_id=test_user.id).first()
+        integration = Integration.query.filter_by(
+            provider="caldav_calendar", user_id=test_user.id
+        ).first()
         assert integration is not None
         assert integration.config["server_url"] == "https://mail.example.com/dav"
         assert integration.config["default_project_id"] == test_project.id
 
         # Verify credentials were saved
-        credentials = IntegrationCredential.query.filter_by(integration_id=integration.id).first()
+        credentials = IntegrationCredential.query.filter_by(
+            integration_id=integration.id
+        ).first()
         assert credentials is not None
         assert credentials.access_token == "testpass"
         assert credentials.extra_data["username"] == "user@example.com"
@@ -377,4 +406,3 @@ class TestIntegrationExternalEventLink:
         db_session.add(link2)
         with pytest.raises(Exception):  # Should raise IntegrityError
             db_session.commit()
-


### PR DESCRIPTION
## Summary

Four integration tests fell behind code changes in `app/integrations/`
and the data model. They were asserting against old data shapes or
patching old mock targets, and only surfaced now that v5.5.6's fixture
refresh re-enabled them in CI.

All three files in this PR are test-only changes — no production code
touched.

## Repairs

### `tests/test_integration/test_caldav_integration.py`

`test_sync_data_imports_events` still expected the connector to write
`TimeEntry` rows and `IntegrationExternalEventLink` rows. The connector
in `app/integrations/caldav_calendar.py:803` (`_sync_calendar_to_time_tracker`)
now writes `CalendarEvent` rows and tracks imports via a `[CalDAV: <uid>]`
marker embedded in the description.

- Update assertions to query `CalendarEvent` and look for the marker.
- Add `CalendarEvent` to the model imports.

### `tests/test_integration/test_activitywatch_integration.py`

Four tests in this file patched `app.integrations.activitywatch.requests.get`.
The connector at `app/integrations/activitywatch.py:78-79` was refactored
to route HTTP through `integration_session()` + `session_request()`, so
`requests.get` is never called and the mocks never fire. Tests that
relied on the mock then attempted real HTTP to `localhost:5600` and
failed.

- Repoint all four `@patch` decorators to
  `app.integrations.activitywatch.session_request`.
- Update the one positional-arg assertion in `test_test_connection_success`
  — URL moves from `call_args[0][0]` to `call_args[0][2]` because
  `session_request`'s signature is `(session, method, url, **kw)`.

### `tests/test_custom_field_definitions.py`

`test_delete_custom_field_preserves_other_fields` called
`test_client.set_custom_field(...)` directly on the fixture instance
which may belong to a different SQLAlchemy session by the time the
test runs. The two JSON mutations weren't reliably persisted, so only
one of the two fields survived to the assertions.

- Re-query the client via `Client.query.get(test_client.id)` before
  mutating. This matches the pattern already used in the surrounding
  tests in the same file (e.g. `test_count_clients_with_value_with_clients`).

## Test plan

- [ ] `pytest tests/test_integration/test_caldav_integration.py::TestCalDAVConnector::test_sync_data_imports_events` passes
- [ ] `pytest tests/test_integration/test_activitywatch_integration.py::TestActivityWatchConnector` — all four tests pass; no real network attempts to `localhost:5600`
- [ ] `pytest tests/test_custom_field_definitions.py::test_delete_custom_field_preserves_other_fields` passes
- [ ] No regression on the other passing tests in these files