### PR TITLE
fix(expenses): include notes field in PATCH update allowlist

### DIFF
--- a/app/routes/api_v1_expenses.py
+++ b/app/routes/api_v1_expenses.py
@@ -140,7 +140,7 @@ def update_expense(expense_id):
 
     data = request.get_json() or {}
     update_kwargs = {}
-    for field in ("title", "description", "category", "currency_code", "payment_method", "status", "tags"):
+    for field in ("title", "description", "category", "currency_code", "payment_method", "status", "tags", "notes"):
         if field in data:
             update_kwargs[field] = data[field]
     if "amount" in data:

--- a/app/services/expense_service.py
+++ b/app/services/expense_service.py
@@ -177,7 +177,7 @@ class ExpenseService:
             return {"success": False, "message": "Access denied", "error": "access_denied"}
 
         # Update fields
-        for field in ("title", "description", "category", "currency_code", "payment_method", "status", "tags"):
+        for field in ("title", "description", "category", "currency_code", "payment_method", "status", "tags", "notes"):
             if field in kwargs:
                 setattr(expense, field, kwargs[field])
         if "amount" in kwargs:


### PR DESCRIPTION
## Summary

The `Expense` model has a `notes` Text column
([`app/models/expense.py:59`](../blob/main/app/models/expense.py#L59))
and `Expense.to_dict()` returns it
([`app/models/expense.py:210`](../blob/main/app/models/expense.py#L210)),
but both the PATCH route handler and the `ExpenseService.update_expense`
allowlist tuples omit `notes` from the set of mutable fields.

As a result, callers can send `{"notes": "..."}` in a `PATCH /api/v1/expenses/<id>`
body and get a `200 OK` back with the new value **silently dropped**.
The next `GET` still returns the old value (or `None` on a fresh row).
That's exactly what `tests/test_api_expenses_v1.py::test_expenses_crud`
catches when it sends `notes="airport ride"` and reads back `None`.

## Fix

Add `"notes"` to the two allowlist tuples:

```diff
# app/routes/api_v1_expenses.py
-    for field in ("title", "description", "category", "currency_code", "payment_method", "status", "tags"):
+    for field in ("title", "description", "category", "currency_code", "payment_method", "status", "tags", "notes"):

# app/services/expense_service.py
-        for field in ("title", "description", "category", "currency_code", "payment_method", "status", "tags"):
+        for field in ("title", "description", "category", "currency_code", "payment_method", "status", "tags", "notes"):
```

No model or schema change required — the column already exists. `+1`
field per file, 2-line diff total.

## Test plan

- [ ] `pytest tests/test_api_expenses_v1.py::test_expenses_crud` passes
- [ ] `PATCH /api/v1/expenses/<id>` with `{"notes": "..."}` body persists the value
- [ ] No regression on other expense fields (title, description, category, currency_code, payment_method, status, tags, amount, dates, booleans all still update)