### PR TITLE
test(api-v1): use unique tempfile path per fixture, not hardcoded sqlite name

### DIFF
--- a/tests/test_api_audit_activities_v1.py
+++ b/tests/test_api_audit_activities_v1.py
@@ -1,4 +1,7 @@
 import pytest
+import uuid
+import tempfile
+import os
 
 pytestmark = [pytest.mark.api, pytest.mark.integration]
 
@@ -8,10 +11,12 @@ from app.models import User, ApiToken
 
 @pytest.fixture
 def app():
+    unique_db_path = os.path.join(tempfile.gettempdir(), f"test_api_audit_activities_{uuid.uuid4().hex}.sqlite")
+
     app = create_app(
         {
             "TESTING": True,
-            "SQLALCHEMY_DATABASE_URI": "sqlite:///test_api_audit_activities.sqlite",
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{unique_db_path}",
             "WTF_CSRF_ENABLED": False,
         }
     )

--- a/tests/test_api_budget_alerts_v1.py
+++ b/tests/test_api_budget_alerts_v1.py
@@ -1,4 +1,7 @@
 import pytest
+import uuid
+import tempfile
+import os
 
 pytestmark = [pytest.mark.api, pytest.mark.integration]
 
@@ -8,10 +11,12 @@ from app.models import User, Project, ApiToken
 
 @pytest.fixture
 def app():
+    unique_db_path = os.path.join(tempfile.gettempdir(), f"test_api_budget_alerts_{uuid.uuid4().hex}.sqlite")
+
     app = create_app(
         {
             "TESTING": True,
-            "SQLALCHEMY_DATABASE_URI": "sqlite:///test_api_budget_alerts.sqlite",
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{unique_db_path}",
             "WTF_CSRF_ENABLED": False,
         }
     )

--- a/tests/test_api_calendar_v1.py
+++ b/tests/test_api_calendar_v1.py
@@ -1,4 +1,7 @@
 import pytest
+import uuid
+import tempfile
+import os
 
 pytestmark = [pytest.mark.api, pytest.mark.integration]
 
@@ -10,10 +13,12 @@ from app.models import User, ApiToken
 
 @pytest.fixture
 def app():
+    unique_db_path = os.path.join(tempfile.gettempdir(), f"test_api_calendar_{uuid.uuid4().hex}.sqlite")
+
     app = create_app(
         {
             "TESTING": True,
-            "SQLALCHEMY_DATABASE_URI": "sqlite:///test_api_calendar.sqlite",
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{unique_db_path}",
             "WTF_CSRF_ENABLED": False,
         }
     )

--- a/tests/test_api_client_notes_v1.py
+++ b/tests/test_api_client_notes_v1.py
@@ -1,4 +1,7 @@
 import pytest
+import uuid
+import tempfile
+import os
 
 pytestmark = [pytest.mark.api, pytest.mark.integration]
 
@@ -8,10 +11,12 @@ from app.models import User, Client, ApiToken
 
 @pytest.fixture
 def app():
+    unique_db_path = os.path.join(tempfile.gettempdir(), f"test_api_client_notes_{uuid.uuid4().hex}.sqlite")
+
     app = create_app(
         {
             "TESTING": True,
-            "SQLALCHEMY_DATABASE_URI": "sqlite:///test_api_client_notes.sqlite",
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{unique_db_path}",
             "WTF_CSRF_ENABLED": False,
         }
     )

--- a/tests/test_api_comments_v1.py
+++ b/tests/test_api_comments_v1.py
@@ -1,4 +1,7 @@
 import pytest
+import uuid
+import tempfile
+import os
 
 pytestmark = [pytest.mark.api, pytest.mark.integration]
 
@@ -8,10 +11,12 @@ from app.models import User, Project, Task, ApiToken
 
 @pytest.fixture
 def app():
+    unique_db_path = os.path.join(tempfile.gettempdir(), f"test_api_comments_{uuid.uuid4().hex}.sqlite")
+
     app = create_app(
         {
             "TESTING": True,
-            "SQLALCHEMY_DATABASE_URI": "sqlite:///test_api_comments.sqlite",
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{unique_db_path}",
             "WTF_CSRF_ENABLED": False,
         }
     )

--- a/tests/test_api_credit_notes_v1.py
+++ b/tests/test_api_credit_notes_v1.py
@@ -1,4 +1,7 @@
 import pytest
+import uuid
+import tempfile
+import os
 
 pytestmark = [pytest.mark.api, pytest.mark.integration]
 
@@ -10,10 +13,12 @@ from app.models import User, Client, Project, Invoice, ApiToken
 
 @pytest.fixture
 def app():
+    unique_db_path = os.path.join(tempfile.gettempdir(), f"test_api_credit_notes_{uuid.uuid4().hex}.sqlite")
+
     app = create_app(
         {
             "TESTING": True,
-            "SQLALCHEMY_DATABASE_URI": "sqlite:///test_api_credit_notes.sqlite",
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{unique_db_path}",
             "WTF_CSRF_ENABLED": False,
         }
     )

--- a/tests/test_api_expenses_v1.py
+++ b/tests/test_api_expenses_v1.py
@@ -1,4 +1,7 @@
 import pytest
+import uuid
+import tempfile
+import os
 
 pytestmark = [pytest.mark.api, pytest.mark.integration]
 
@@ -10,10 +13,12 @@ from app.models import User, Expense, ApiToken
 
 @pytest.fixture
 def app():
+    unique_db_path = os.path.join(tempfile.gettempdir(), f"test_api_expenses_{uuid.uuid4().hex}.sqlite")
+
     app = create_app(
         {
             "TESTING": True,
-            "SQLALCHEMY_DATABASE_URI": "sqlite:///test_api_expenses.sqlite",
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{unique_db_path}",
             "WTF_CSRF_ENABLED": False,
         }
     )

--- a/tests/test_api_favorites_v1.py
+++ b/tests/test_api_favorites_v1.py
@@ -1,4 +1,7 @@
 import pytest
+import uuid
+import tempfile
+import os
 
 pytestmark = [pytest.mark.api, pytest.mark.integration]
 
@@ -8,10 +11,12 @@ from app.models import User, Project, Client, ApiToken
 
 @pytest.fixture
 def app():
+    unique_db_path = os.path.join(tempfile.gettempdir(), f"test_api_favorites_{uuid.uuid4().hex}.sqlite")
+
     app = create_app(
         {
             "TESTING": True,
-            "SQLALCHEMY_DATABASE_URI": "sqlite:///test_api_favorites.sqlite",
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{unique_db_path}",
             "WTF_CSRF_ENABLED": False,
         }
     )

--- a/tests/test_api_invoice_templates_api_v1.py
+++ b/tests/test_api_invoice_templates_api_v1.py
@@ -1,4 +1,7 @@
 import pytest
+import uuid
+import tempfile
+import os
 
 pytestmark = [pytest.mark.api, pytest.mark.integration]
 
@@ -8,10 +11,12 @@ from app.models import User, ApiToken
 
 @pytest.fixture
 def app():
+    unique_db_path = os.path.join(tempfile.gettempdir(), f"test_api_invoice_templates_{uuid.uuid4().hex}.sqlite")
+
     app = create_app(
         {
             "TESTING": True,
-            "SQLALCHEMY_DATABASE_URI": "sqlite:///test_api_invoice_templates.sqlite",
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{unique_db_path}",
             "WTF_CSRF_ENABLED": False,
         }
     )

--- a/tests/test_api_invoice_templates_v1.py
+++ b/tests/test_api_invoice_templates_v1.py
@@ -1,4 +1,7 @@
 import pytest
+import uuid
+import tempfile
+import os
 
 pytestmark = [pytest.mark.api, pytest.mark.integration]
 
@@ -8,10 +11,12 @@ from app.models import User, ApiToken
 
 @pytest.fixture
 def app():
+    unique_db_path = os.path.join(tempfile.gettempdir(), f"test_api_invoice_templates_{uuid.uuid4().hex}.sqlite")
+
     app = create_app(
         {
             "TESTING": True,
-            "SQLALCHEMY_DATABASE_URI": "sqlite:///test_api_invoice_templates.sqlite",
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{unique_db_path}",
             "WTF_CSRF_ENABLED": False,
         }
     )

--- a/tests/test_api_invoices_v1.py
+++ b/tests/test_api_invoices_v1.py
@@ -1,4 +1,7 @@
 import json
+import uuid
+import tempfile
+import os
 import pytest
 
 pytestmark = [pytest.mark.api, pytest.mark.integration]
@@ -11,10 +14,12 @@ from app.models import User, Client, Project, Invoice, ApiToken
 
 @pytest.fixture
 def app():
+    unique_db_path = os.path.join(tempfile.gettempdir(), f"test_api_invoices_{uuid.uuid4().hex}.sqlite")
+
     app = create_app(
         {
             "TESTING": True,
-            "SQLALCHEMY_DATABASE_URI": "sqlite:///test_api_invoices.sqlite",
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{unique_db_path}",
             "WTF_CSRF_ENABLED": False,
         }
     )

--- a/tests/test_api_kanban_v1.py
+++ b/tests/test_api_kanban_v1.py
@@ -1,4 +1,7 @@
 import pytest
+import uuid
+import tempfile
+import os
 
 pytestmark = [pytest.mark.api, pytest.mark.integration]
 
@@ -8,10 +11,12 @@ from app.models import User, ApiToken
 
 @pytest.fixture
 def app():
+    unique_db_path = os.path.join(tempfile.gettempdir(), f"test_api_kanban_{uuid.uuid4().hex}.sqlite")
+
     app = create_app(
         {
             "TESTING": True,
-            "SQLALCHEMY_DATABASE_URI": "sqlite:///test_api_kanban.sqlite",
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{unique_db_path}",
             "WTF_CSRF_ENABLED": False,
         }
     )

--- a/tests/test_api_mileage_v1.py
+++ b/tests/test_api_mileage_v1.py
@@ -1,4 +1,7 @@
 import pytest
+import uuid
+import tempfile
+import os
 
 pytestmark = [pytest.mark.api, pytest.mark.integration]
 
@@ -10,10 +13,12 @@ from app.models import User, ApiToken
 
 @pytest.fixture
 def app():
+    unique_db_path = os.path.join(tempfile.gettempdir(), f"test_api_mileage_{uuid.uuid4().hex}.sqlite")
+
     app = create_app(
         {
             "TESTING": True,
-            "SQLALCHEMY_DATABASE_URI": "sqlite:///test_api_mileage.sqlite",
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{unique_db_path}",
             "WTF_CSRF_ENABLED": False,
         }
     )

--- a/tests/test_api_payments_v1.py
+++ b/tests/test_api_payments_v1.py
@@ -1,4 +1,7 @@
 import pytest
+import uuid
+import tempfile
+import os
 
 pytestmark = [pytest.mark.api, pytest.mark.integration]
 
@@ -10,10 +13,12 @@ from app.models import User, Client, Project, Invoice, ApiToken
 
 @pytest.fixture
 def app():
+    unique_db_path = os.path.join(tempfile.gettempdir(), f"test_api_payments_{uuid.uuid4().hex}.sqlite")
+
     app = create_app(
         {
             "TESTING": True,
-            "SQLALCHEMY_DATABASE_URI": "sqlite:///test_api_payments.sqlite",
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{unique_db_path}",
             "WTF_CSRF_ENABLED": False,
         }
     )

--- a/tests/test_api_per_diem_v1.py
+++ b/tests/test_api_per_diem_v1.py
@@ -1,4 +1,7 @@
 import pytest
+import uuid
+import tempfile
+import os
 
 pytestmark = [pytest.mark.api, pytest.mark.integration]
 
@@ -10,10 +13,12 @@ from app.models import User, ApiToken
 
 @pytest.fixture
 def app():
+    unique_db_path = os.path.join(tempfile.gettempdir(), f"test_api_per_diem_{uuid.uuid4().hex}.sqlite")
+
     app = create_app(
         {
             "TESTING": True,
-            "SQLALCHEMY_DATABASE_URI": "sqlite:///test_api_per_diem.sqlite",
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{unique_db_path}",
             "WTF_CSRF_ENABLED": False,
         }
     )

--- a/tests/test_api_project_costs_v1.py
+++ b/tests/test_api_project_costs_v1.py
@@ -1,4 +1,7 @@
 import pytest
+import uuid
+import tempfile
+import os
 
 pytestmark = [pytest.mark.api, pytest.mark.integration]
 
@@ -10,10 +13,12 @@ from app.models import User, Project, Client, ApiToken
 
 @pytest.fixture
 def app():
+    unique_db_path = os.path.join(tempfile.gettempdir(), f"test_api_project_costs_{uuid.uuid4().hex}.sqlite")
+
     app = create_app(
         {
             "TESTING": True,
-            "SQLALCHEMY_DATABASE_URI": "sqlite:///test_api_project_costs.sqlite",
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{unique_db_path}",
             "WTF_CSRF_ENABLED": False,
         }
     )

--- a/tests/test_api_recurring_invoices_v1.py
+++ b/tests/test_api_recurring_invoices_v1.py
@@ -1,4 +1,7 @@
 import pytest
+import uuid
+import tempfile
+import os
 
 pytestmark = [pytest.mark.api, pytest.mark.integration]
 
@@ -10,10 +13,12 @@ from app.models import User, Client, Project, ApiToken
 
 @pytest.fixture
 def app():
+    unique_db_path = os.path.join(tempfile.gettempdir(), f"test_api_recurring_{uuid.uuid4().hex}.sqlite")
+
     app = create_app(
         {
             "TESTING": True,
-            "SQLALCHEMY_DATABASE_URI": "sqlite:///test_api_recurring.sqlite",
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{unique_db_path}",
             "WTF_CSRF_ENABLED": False,
         }
     )

--- a/tests/test_api_saved_filters_v1.py
+++ b/tests/test_api_saved_filters_v1.py
@@ -1,4 +1,7 @@
 import pytest
+import uuid
+import tempfile
+import os
 
 pytestmark = [pytest.mark.api, pytest.mark.integration]
 
@@ -8,10 +11,12 @@ from app.models import User, ApiToken
 
 @pytest.fixture
 def app():
+    unique_db_path = os.path.join(tempfile.gettempdir(), f"test_api_saved_filters_{uuid.uuid4().hex}.sqlite")
+
     app = create_app(
         {
             "TESTING": True,
-            "SQLALCHEMY_DATABASE_URI": "sqlite:///test_api_saved_filters.sqlite",
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{unique_db_path}",
             "WTF_CSRF_ENABLED": False,
         }
     )

--- a/tests/test_api_tax_currency_v1.py
+++ b/tests/test_api_tax_currency_v1.py
@@ -1,4 +1,7 @@
 import pytest
+import uuid
+import tempfile
+import os
 
 pytestmark = [pytest.mark.api, pytest.mark.integration]
 
@@ -10,10 +13,12 @@ from app.models import User, ApiToken
 
 @pytest.fixture
 def app():
+    unique_db_path = os.path.join(tempfile.gettempdir(), f"test_api_tax_currency_{uuid.uuid4().hex}.sqlite")
+
     app = create_app(
         {
             "TESTING": True,
-            "SQLALCHEMY_DATABASE_URI": "sqlite:///test_api_tax_currency.sqlite",
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{unique_db_path}",
             "WTF_CSRF_ENABLED": False,
         }
     )

--- a/tests/test_api_time_entry_templates_v1.py
+++ b/tests/test_api_time_entry_templates_v1.py
@@ -1,4 +1,7 @@
 import pytest
+import uuid
+import tempfile
+import os
 
 pytestmark = [pytest.mark.api, pytest.mark.integration]
 
@@ -8,10 +11,12 @@ from app.models import User, ApiToken
 
 @pytest.fixture
 def app():
+    unique_db_path = os.path.join(tempfile.gettempdir(), f"test_api_templates_{uuid.uuid4().hex}.sqlite")
+
     app = create_app(
         {
             "TESTING": True,
-            "SQLALCHEMY_DATABASE_URI": "sqlite:///test_api_templates.sqlite",
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{unique_db_path}",
             "WTF_CSRF_ENABLED": False,
         }
     )


### PR DESCRIPTION
## Summary

20 test files (`tests/test_api_*_v1.py`) share an anti-pattern: each
declares its own local `app` fixture with a **hardcoded SQLite
filename in the test runner's CWD**, e.g.

```python
"SQLALCHEMY_DATABASE_URI": "sqlite:///test_api_kanban.sqlite",
```

This causes two real problems:

### 1. State leaks between runs

If a prior test run crashed or was killed before the fixture teardown
ran, the `.sqlite` file persists. The next run starts on a non-empty
database and trips over FK / uniqueness constraints. `test_tax_currency_flow`
surfaces this as a `409 Conflict` when its `USD` currency row already
exists from a previous run — the route's `IntegrityError` handler maps
the unique-constraint violation to 409 instead of the expected 201.

### 2. Collisions between test files

Two files share the same filename:

- `tests/test_api_invoice_templates_v1.py` → `test_api_invoice_templates.sqlite`
- `tests/test_api_invoice_templates_api_v1.py` → `test_api_invoice_templates.sqlite`

Under `pytest-xdist` they race for the same file and corrupt each other's
state.

## Fix

Each fixture now generates a **unique per-call path** using the same
pattern already established in `tests/conftest.py:204`:

```python
unique_db_path = os.path.join(
    tempfile.gettempdir(), f"test_<slug>_{uuid.uuid4().hex}.sqlite"
)
"SQLALCHEMY_DATABASE_URI": f"sqlite:///{unique_db_path}",
```

Adds `import os`, `import tempfile`, `import uuid` where missing in each
file. Test lifecycle is unchanged — the existing fixture teardown
(`db.drop_all()` + engine dispose) still runs; the OS later reaps the
temp file. Black-formatted to the project's 120-char line limit.

## Diff shape

7 lines changed per file × 20 files = 140 lines of identical pattern.

## Test plan

- [ ] `pytest tests/test_api_kanban_v1.py` — passes
- [ ] `pytest tests/test_api_tax_currency_v1.py` — no leftover-`USD` 409 on second run
- [ ] `pytest -p xdist -n 2 tests/test_api_invoice_templates_v1.py tests/test_api_invoice_templates_api_v1.py` — no collision
- [ ] Run the full `tests/test_api_*_v1.py` suite twice in a row — second run starts clean (no leftover .sqlite files in repo root)
- [ ] No regression on tests using the central `conftest.py` `app` fixture (unchanged)