### PR TITLE
test(oidc): pre-create user so callback reaches token-storage code

### DIFF
--- a/tests/test_oidc_session_cookie_bloat.py
+++ b/tests/test_oidc_session_cookie_bloat.py
@@ -53,10 +53,23 @@ def test_oidc_callback_does_not_store_id_token_in_cookie_session(app, client):
             stored.pop(key, None)
 
     with app.app_context():
+        from app import db
+        from app.models import User
+
         app.config["AUTH_METHOD"] = "oidc"
         app.config["PERMANENT_SESSION_LIFETIME"] = app.config.get("PERMANENT_SESSION_LIFETIME")
 
-        with patch("app.routes.auth.oauth") as mock_oauth, patch("app.routes.auth.get_cache", return_value=DummyCache()):
+        # Pre-create the user the OIDC callback will match. Without this the
+        # callback redirects to /login with "self-registration disabled"
+        # before reaching the token-storage code this test is exercising.
+        user = User(username="oidc_bloat_test", email="oidc_bloat_test@example.com")
+        user.is_active = True
+        db.session.add(user)
+        db.session.commit()
+
+        with patch("app.routes.auth.oauth") as mock_oauth, patch(
+            "app.routes.auth.get_cache", return_value=DummyCache()
+        ):
             mock_oauth.create_client.return_value = DummyOidcClient()
 
             # Act: hit callback


### PR DESCRIPTION
## Summary

`tests/test_oidc_session_cookie_bloat.py::test_oidc_callback_does_not_store_id_token_in_cookie_session`
has been failing on every comprehensive CI run for weeks with:

```
AssertionError: assert 'oidc_id_token_key' in
    <SecureCookieSession {'_flashes': [('error',
    'User account does not exist and self-registration is disabled.')]}>
```

## Root cause

The OIDC callback flow in `app/routes/auth.py:1322-1346` is:

1. Find or create a `User` matching the incoming token's identity (oidc_sub, email, username).
2. If not found and self-registration is disabled, flash an error and redirect to `/login`.
3. If found (or self-registered), continue to the post-auth code that stores the id_token server-side and puts only a short key in `session["oidc_id_token_key"]`.

The test exercises step 3 (session bloat protection). But in the test
environment `ALLOW_SELF_REGISTER` is `False` (the production-safe
default at `app/config.py:45`), and the test doesn't pre-create a
matching user. So step 2 fires the "self-registration disabled" error
and the redirect happens *before* the token-storage code under test
runs. The final session has the flash message but never gets
`oidc_id_token_key`.

## Fix

Pre-create a `User` row matching the fake OIDC subject's `username` and
`email` so the lookup at step 1 succeeds. The callback then proceeds to
step 3 and exercises the actual session-bloat protection.

```python
user = User(username="oidc_bloat_test", email="oidc_bloat_test@example.com")
user.is_active = True
db.session.add(user)
db.session.commit()
```

The test is about how the token is stored — not about the user-creation
path. Making it independent of the `ALLOW_SELF_REGISTER` setting keeps
the test focused on its actual subject.

## Test plan

- [ ] `pytest tests/test_oidc_session_cookie_bloat.py::test_oidc_callback_does_not_store_id_token_in_cookie_session` passes
- [ ] The assertions about server-side cache storage and absence of `oidc_id_token` in the session cookie still hold