### PR TITLE
fix(test): _refactored tests use FlaskClient as 'client', mileage float mismatch

### DIFF
--- a/tests/test_routes/test_api_v1_invoices_tasks_expenses_refactored.py
+++ b/tests/test_routes/test_api_v1_invoices_tasks_expenses_refactored.py
@@ -52,13 +52,13 @@ class TestAPIInvoicesRefactored:
         assert "invoice" in data
         assert data["invoice"]["id"] == invoice.id
 
-    def test_create_invoice_uses_service_layer(self, app, client_with_token, project, client):
+    def test_create_invoice_uses_service_layer(self, app, client_with_token, project, test_client):
         """Test that create_invoice route uses service layer"""
         response = client_with_token.post(
             "/api/v1/invoices",
             json={
                 "project_id": project.id,
-                "client_id": client.id,
+                "client_id": test_client.id,
                 "client_name": client.name,
                 "due_date": (date.today() + timedelta(days=30)).isoformat(),
                 "notes": "Test invoice",

--- a/tests/test_routes/test_api_v1_mileage_refactored.py
+++ b/tests/test_routes/test_api_v1_mileage_refactored.py
@@ -72,7 +72,7 @@ class TestAPIMileageRefactored:
         assert response.status_code == 201
         data = response.get_json()
         assert "mileage" in data
-        assert data["mileage"]["distance_km"] == "50.5"
+        assert data["mileage"]["distance_km"] == 50.5
 
     def test_update_mileage(self, app, client_with_token, mileage):
         """Test update_mileage route"""

--- a/tests/test_routes/test_api_v1_projects_refactored.py
+++ b/tests/test_routes/test_api_v1_projects_refactored.py
@@ -51,11 +51,11 @@ class TestAPIProjectsRefactored:
         assert "project" in data
         assert data["project"]["id"] == project.id
 
-    def test_create_project_uses_service_layer(self, app, client_with_token, client):
+    def test_create_project_uses_service_layer(self, app, client_with_token, test_client):
         """Test that create_project route uses service layer"""
         response = client_with_token.post(
             "/api/v1/projects",
-            json={"name": "API Test Project", "client_id": client.id, "billable": True},
+            json={"name": "API Test Project", "client_id": test_client.id, "billable": True},
             content_type="application/json",
         )
 
@@ -103,9 +103,9 @@ class TestAPIProjectsRefactored:
         db.session.refresh(project)
         assert project.status == "archived"
 
-    def test_list_projects_with_filters(self, app, client_with_token, project, client):
+    def test_list_projects_with_filters(self, app, client_with_token, project, test_client):
         """Test list_projects with status and client filters"""
-        response = client_with_token.get(f"/api/v1/projects?status=active&client_id={client.id}")
+        response = client_with_token.get(f"/api/v1/projects?status=active&client_id={test_client.id}")
 
         assert response.status_code == 200
         data = response.get_json()
@@ -113,4 +113,4 @@ class TestAPIProjectsRefactored:
         # All returned projects should match filters
         for p in data["projects"]:
             assert p["status"] == "active"
-            assert p["client_id"] == client.id
+            assert p["client_id"] == test_client.id

--- a/tests/test_routes/test_api_v1_quotes_refactored.py
+++ b/tests/test_routes/test_api_v1_quotes_refactored.py
@@ -50,12 +50,12 @@ class TestAPIQuotesRefactored:
         assert "quote" in data
         assert data["quote"]["id"] == quote.id
 
-    def test_create_quote_uses_service_layer(self, app, client_with_token, client):
+    def test_create_quote_uses_service_layer(self, app, client_with_token, test_client):
         """Test that create_quote route uses service layer"""
         response = client_with_token.post(
             "/api/v1/quotes",
             json={
-                "client_id": client.id,
+                "client_id": test_client.id,
                 "title": "Test Quote",
                 "description": "Test description",
                 "tax_rate": 21.0,


### PR DESCRIPTION
## Summary

Two narrow, independent bugs in `tests/test_routes/test_api_v1_*_refactored.py`
that have been failing on every comprehensive CI run.

### 1. Fixture name collision: `client` is the Flask test client

Four test methods declared `client` as a fixture parameter expecting a
`Client` model row:

```python
def test_create_project_uses_service_layer(self, app, client_with_token, client):
    response = client_with_token.post(
        "/api/v1/projects",
        json={"name": "API Test Project", "client_id": client.id, "billable": True},
        ...
    )
```

But `conftest.py`'s `client` fixture returns the Flask test client
(`FlaskClient`), not a Client model row. `client.id` therefore raised:

```
AttributeError: 'FlaskClient' object has no attribute 'id'
```

The Client model row is exposed by `conftest.py` as `test_client`.
Rename the parameter and the `.id` references in four methods:

- `test_create_project_uses_service_layer`
- `test_list_projects_with_filters`
- `test_create_quote_uses_service_layer`
- `test_create_invoice_uses_service_layer`

### 2. `distance_km` is returned as a float, not a string

`test_create_mileage` asserts:

```python
assert data["mileage"]["distance_km"] == "50.5"
```

but `Mileage.to_dict()` returns `float(self.distance_km)` (see
`app/models/mileage.py:192`). The string assertion never matches.
Fix the test to compare to the float `50.5`. The API behaviour is
the intended one — the assertion was stale.

## Test plan

- [ ] `pytest tests/test_routes/test_api_v1_projects_refactored.py`
- [ ] `pytest tests/test_routes/test_api_v1_quotes_refactored.py`
- [ ] `pytest tests/test_routes/test_api_v1_invoices_tasks_expenses_refactored.py::TestAPIInvoicesRefactored::test_create_invoice_uses_service_layer`
- [ ] `pytest tests/test_routes/test_api_v1_mileage_refactored.py::TestAPIMileageRefactored::test_create_mileage`

## Files changed

- `tests/test_routes/test_api_v1_projects_refactored.py`
- `tests/test_routes/test_api_v1_quotes_refactored.py`
- `tests/test_routes/test_api_v1_invoices_tasks_expenses_refactored.py`
- `tests/test_routes/test_api_v1_mileage_refactored.py`

10-line surgical diff, test-only.