### PR TITLE
test(project_costs): add SECRET_KEY to local fixture so create_app boots

### DIFF
--- a/tests/test_project_costs.py
+++ b/tests/test_project_costs.py
@@ -22,7 +22,14 @@ pytestmark = [pytest.mark.unit, pytest.mark.models]
 @pytest.fixture
 def app():
     """Create and configure a test application instance."""
-    app = create_app({"TESTING": True, "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:", "WTF_CSRF_ENABLED": False})
+    app = create_app(
+        {
+            "TESTING": True,
+            "SECRET_KEY": "test-secret-key",
+            "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+            "WTF_CSRF_ENABLED": False,
+        }
+    )
 
     with app.app_context():
         db.create_all()


### PR DESCRIPTION
## Summary

All **23 tests** in `tests/test_project_costs.py` are reported as ERROR
(fixture-setup failure) in the comprehensive CI run from a single root
cause.

## Root cause

The file's local `app` fixture (line 22-31) passes only:

```python
create_app({"TESTING": True, "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:", "WTF_CSRF_ENABLED": False})
```

It does **not** supply `SECRET_KEY`. The Unit Tests job in
`.github/workflows/ci-comprehensive.yml` (lines 96-106) doesn't export
`FLASK_ENV` either, so `create_app(...)` resolves to `ProductionConfig`,
which inherits

```python
SECRET_KEY = os.getenv("SECRET_KEY", "dev-secret-key-change-in-production")
```

The production-safety guard at `app/__init__.py:180-187` then raises

```
ValueError: SECRET_KEY must be set explicitly in production.
```

inside the fixture, so every test in the file is reported as **ERROR**
before `db.create_all()` runs.

The guard was added in 531f16b5 (2026-03-06); the local fixture
predates it and was left behind. Every other test module uses the
project-wide `app` fixture in `tests/conftest.py:200` which already
sets both `FLASK_ENV: "testing"` and a non-sentinel `SECRET_KEY` (lines
187-190), which is why they're unaffected.

## Fix

Add `"SECRET_KEY": "test-secret-key"` to the local fixture's config
dict. Minimum-surgery test-only change. The model code (`app/models/project_cost.py`)
and the production-safety guard are both correct; only the test fixture
was stale.

```diff
-    app = create_app({"TESTING": True, "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:", "WTF_CSRF_ENABLED": False})
+    app = create_app(
+        {
+            "TESTING": True,
+            "SECRET_KEY": "test-secret-key",
+            "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+            "WTF_CSRF_ENABLED": False,
+        }
+    )
```

## Possible follow-up (not in this PR)

The cleaner alternative is to delete the local `app` fixture entirely
and rely on the conftest's central one, which additionally seeds
baseline `Role` rows, creates default `Settings`, uses a unique
per-test sqlite path, and disposes the engine on teardown. That's a
bigger refactor — left for a future PR.

## Test plan

- [ ] `pytest tests/test_project_costs.py` — all 23 tests reach their assertions instead of erroring at setup
- [ ] No regression on other test files that use the central `app` fixture (unchanged)