### PR TITLE
test(webhook): disable retries in fixture so failure tests see 'failed' status

### DIFF
--- a/tests/test_utils/test_webhook_service.py
+++ b/tests/test_utils/test_webhook_service.py
@@ -28,6 +28,11 @@ def test_webhook(db_session, test_user):
         events=["project.created"],
         user_id=test_user.id,
         is_active=True,
+        # Disable retries so timeout/http-error tests can assert the
+        # immediate `failed` status without _schedule_retry flipping it
+        # to `retrying`. Retry behaviour itself is exercised in
+        # test_retry_failed_deliveries.
+        max_retries=0,
     )
     webhook.set_secret()
     db_session.add(webhook)


### PR DESCRIPTION
## Summary

Two tests in `tests/test_utils/test_webhook_service.py` have been
failing in every CI run:

- `TestWebhookService::test_deliver_webhook_timeout`
- `TestWebhookService::test_deliver_webhook_http_error`

Both assert `delivery.status == 'failed'` after a request error, but
the actual status comes back as `'retrying'`.

## Root cause

The `test_webhook` fixture (line 23) creates a `Webhook` with the model
default `max_retries=3`. The delivery flow at
`app/utils/webhook_service.py:127-141` does:

```python
delivery.mark_failed(error_type='timeout', ...)
...
WebhookService._schedule_retry(delivery, webhook)
```

and `_schedule_retry` at line 244 calls `delivery.mark_retrying(...)`
when `retry_count < max_retries`. With `max_retries=3`, the very first
attempt gets retried, so `delivery.status` ends as `'retrying'` rather
than the initial `'failed'`.

## Fix

Set `max_retries=0` on the `test_webhook` fixture. The two failing
tests are checking *immediate* failure handling (the timeout / HTTP
error path), not retry orchestration. Isolating that concern keeps
the assertions accurate.

Retry behaviour itself is covered by `test_retry_failed_deliveries`
elsewhere in the same file, which can use a separate fixture with
retries enabled if needed (it currently relies on direct manipulation
of `delivery.status` and doesn't need `max_retries`).

No service-code change required — the service is doing the correct
thing for the production scenario (webhooks retry by default).

```diff
 webhook = Webhook(
     name="Test Webhook",
     url="https://example.com/webhook",
     events=["project.created"],
     user_id=test_user.id,
     is_active=True,
+    max_retries=0,
 )
```

## Test plan

- [ ] `pytest tests/test_utils/test_webhook_service.py::TestWebhookService::test_deliver_webhook_timeout` passes
- [ ] `pytest tests/test_utils/test_webhook_service.py::TestWebhookService::test_deliver_webhook_http_error` passes
- [ ] `pytest tests/test_utils/test_webhook_service.py::TestWebhookService::test_deliver_webhook_success` continues to pass (success path doesn't touch retries)
- [ ] `pytest tests/test_utils/test_webhook_service.py::TestWebhookService::test_retry_failed_deliveries` continues to pass (uses direct status manipulation, not max_retries)