### PR TITLE
fix(invoice,payment): correct totals on invoice-from-entries and payment delete

### DIFF
--- a/app/services/invoice_service.py
+++ b/app/services/invoice_service.py
@@ -85,6 +85,11 @@ class InvoiceService:
             created_by=created_by,
         )
 
+        # Flush so the invoice receives its primary key before we build the
+        # invoice items below — InvoiceItem.invoice_id is NOT NULL, and the
+        # repository's create() only adds to the session without flushing.
+        db.session.flush()
+
         # Create invoice items from time entries
         # Group entries by task for better organization
         grouped_entries: Dict[str, Dict[str, Any]] = {}
@@ -127,6 +132,14 @@ class InvoiceService:
                 time_entry_ids=time_entry_ids_csv,
             )
             db.session.add(item)
+
+        # Derive subtotal/tax/total from the persisted line items. Invoice.__init__
+        # ignores subtotal/tax_amount/total_amount kwargs, so the values passed to
+        # invoice_repo.create() above never stick; recompute from the items (whose
+        # total_amount auto-computes from quantity * unit_price) as the source of
+        # truth. Flush first so invoice.items reflects the rows just added.
+        db.session.flush()
+        invoice.calculate_totals()
 
         if not safe_commit("create_invoice", {"project_id": project_id, "created_by": created_by}):
             return {

--- a/app/services/payment_service.py
+++ b/app/services/payment_service.py
@@ -174,23 +174,29 @@ class PaymentService:
         if not payment:
             return {"success": False, "message": "Payment not found", "error": "not_found"}
 
+        invoice = payment.invoice
         invoice_id = payment.invoice_id
 
         # Delete payment
         db.session.delete(payment)
+        # Flush so the just-deleted payment is excluded from the recomputed
+        # total below; otherwise get_total_for_invoice still counts it and the
+        # status never changes.
+        db.session.flush()
 
-        # Update invoice payment status
-        if payment.invoice:
+        # Update invoice payment status from the remaining payments
+        if invoice:
             total_payments = self.payment_repo.get_total_for_invoice(invoice_id)
-            payment.invoice.amount_paid = total_payments
+            invoice.amount_paid = total_payments
 
-            # Update payment status
-            if payment.invoice.amount_paid >= payment.invoice.total_amount:
-                payment.invoice.payment_status = "fully_paid"
-            elif payment.invoice.amount_paid > 0:
-                payment.invoice.payment_status = "partially_paid"
+            # No remaining payment means unpaid regardless of the invoice total
+            # (a 0 total must not read as "fully_paid" when nothing was paid).
+            if invoice.amount_paid <= 0:
+                invoice.payment_status = "unpaid"
+            elif invoice.amount_paid >= invoice.total_amount:
+                invoice.payment_status = "fully_paid"
             else:
-                payment.invoice.payment_status = "unpaid"
+                invoice.payment_status = "partially_paid"
 
         if not safe_commit("delete_payment", {"payment_id": payment_id, "user_id": user_id}):
             return {


### PR DESCRIPTION
Two service-layer financial-correctness bugs, each covered by an **existing** test in `tests/test_services` that fails on `main` today.

## 1. `create_invoice_from_time_entries` produces a 0 subtotal (and can fail to commit)

- It builds `InvoiceItem(invoice_id=invoice.id)` immediately after `invoice_repo.create()`, but the repository's `create()` only adds to the session without flushing — so `invoice.id` is still `None`. On SQLite this commit fails with `NOT NULL constraint failed: invoice_items.invoice_id`. Fix: flush right after creating the invoice so its primary key is assigned.
- Separately, `Invoice.__init__` ignores the `subtotal` / `tax_amount` / `total_amount` kwargs, so the totals the service computes and passes to `create()` never stick — every invoice built from time entries ends up with `subtotal = 0`. Fix: recompute via `invoice.calculate_totals()` from the persisted line items (whose `total_amount` auto-computes from `quantity * unit_price`) after flushing.

## 2. `delete_payment` leaves the invoice status stale

It recomputes the invoice total via `get_total_for_invoice` **before** flushing the delete, so the just-deleted payment is still counted and `payment_status` never changes. Fix: flush the delete first, and check the unpaid case first so an invoice with no remaining payment reads as `unpaid` rather than `fully_paid` (which a 0 total would otherwise produce).

## Test plan

These two existing tests fail before and pass after:

- `tests/test_services/test_invoice_service.py::test_create_invoice_from_time_entries_with_tax`
- `tests/test_services/test_payment_service_complete.py::TestPaymentServiceComplete::test_delete_payment_updates_invoice_status`

The rest of `test_invoice_service.py` / `test_payment_service_complete.py` stay green (13 passed locally with the change).

> Note: these tests live in the back half of the suite alphabetically, so a parallel `pytest -n` run currently never reaches them — it stalls earlier on accumulated audit-flush listeners (see #655). With that fix in, these failures become visible in CI; this PR resolves them.