### PR TITLE
fix(caldav): define DTEND/DURATION for all-day events

### DIFF
--- a/app/integrations/caldav_calendar.py
+++ b/app/integrations/caldav_calendar.py
@@ -353,6 +353,8 @@ class CalDAVClient:
                 if is_all_day:
                     from datetime import date as date_cls
 
+                    dtend = comp.get("DTEND")
+                    duration = comp.get("DURATION")
                     start_date = start
                     if dtend:
                         end_date = dtend.dt


### PR DESCRIPTION
### Problem
In `CalDAVClient.fetch_events`, the all-day-event branch references `dtend` and `duration`, but those names are only assigned later in the **timed-event** branch. The all-day branch `continue`s before reaching that code, so for any all-day `VEVENT` the names are undefined and the sync raises `NameError`.

### Fix
Fetch `DTEND`/`DURATION` from the component at the top of the all-day branch, mirroring the timed-event path. Two-line change; no behavior change for timed events.

### Test plan
- Sync a CalDAV calendar containing an all-day event (birthday/holiday): previously raised `NameError`, now imports with the correct end date (DTEND, else DURATION, else +1 day).
- Timed events unaffected.