### PR TITLE
fix(mobile): resolve Dart compile errors in invoice client/screen

### DIFF
--- a/mobile/lib/data/api/api_client.dart
+++ b/mobile/lib/data/api/api_client.dart
@@ -313,7 +313,7 @@ class ApiClient {
       options: Options(responseType: ResponseType.bytes),
     );
     _throwIfError(res);
-    final data = res.data;
+    final dynamic data = res.data;
     if (data is List<int>) return data;
     if (data is Uint8List) return data.toList();
     return <int>[];

--- a/mobile/lib/presentation/screens/invoice_detail_screen.dart
+++ b/mobile/lib/presentation/screens/invoice_detail_screen.dart
@@ -394,7 +394,7 @@ class _InvoiceDetailScreenState extends ConsumerState<InvoiceDetailScreen> {
           future: _future,
           builder: (context, snapshot) {
             if (snapshot.connectionState == ConnectionState.waiting) {
-              return const ListView(children: [SizedBox(height: 120), Center(child: CircularProgressIndicator())]);
+              return ListView(children: const [SizedBox(height: 120), Center(child: CircularProgressIndicator())]);
             }
             if (snapshot.hasError) {
               return ListView(


### PR DESCRIPTION
### Problem
Two compile errors in the mobile invoice code fail the Flutter build (`flutter test` on the android/ios jobs):

1. `ApiClient.downloadInvoicePdf`: `res.data` is typed `List<int>?`, so after `if (data is List<int>) return data;` the analyzer narrows `data` to `Never?`. The next line `if (data is Uint8List) return data.toList();` then fails to compile — *The method 'toList' isn't defined for the type 'Never?'*.
2. `invoice_detail_screen`: `const ListView(children: [...])` invokes `ListView`'s **non-const** default constructor in a const context — *Cannot invoke a non-'const' constructor where a const expression is expected*.

### Fix
1. Type `data` as `dynamic` so both runtime `is` checks remain valid.
2. Drop `const` on the `ListView` constructor; keep it on the children list (all three children are const-constructible).

### Test plan
- `flutter test` (the android/ios CI jobs) compiles `api_client.dart` and `invoice_detail_screen.dart` and the suite loads — previously failed with the two compile errors above.