### PR TITLE
feat(kanban): add optional per-column WIP limits

### DIFF
--- a/app/models/kanban_column.py
+++ b/app/models/kanban_column.py
@@ -22,6 +22,8 @@ class KanbanColumn(db.Model):
     is_active = db.Column(db.Boolean, default=True, nullable=False)  # Can be disabled without deletion
     is_system = db.Column(db.Boolean, default=False, nullable=False)  # System columns cannot be deleted
     is_complete_state = db.Column(db.Boolean, default=False, nullable=False)  # Marks task as completed
+    # WIP (work-in-progress) limit: max tasks allowed in this column. NULL / 0 = no limit.
+    wip_limit = db.Column(db.Integer, nullable=True)
     created_at = db.Column(db.DateTime, default=now_in_app_timezone, nullable=False)
     updated_at = db.Column(
         db.DateTime,
@@ -54,6 +56,7 @@ class KanbanColumn(db.Model):
             "is_active": self.is_active,
             "is_system": self.is_system,
             "is_complete_state": self.is_complete_state,
+            "wip_limit": self.wip_limit,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }

--- a/app/routes/kanban.py
+++ b/app/routes/kanban.py
@@ -133,6 +133,9 @@ def create_column():
         icon = request.form.get("icon", "fas fa-circle").strip()
         color = request.form.get("color", "secondary").strip()
         is_complete_state = request.form.get("is_complete_state") == "on"
+        wip_limit = request.form.get("wip_limit", type=int)
+        if not wip_limit or wip_limit < 1:
+            wip_limit = None
         project_id = request.form.get("project_id", type=int) or None
 
         # Validate required fields
@@ -169,6 +172,7 @@ def create_column():
             color=color,
             position=max_position + 1,
             is_complete_state=is_complete_state,
+            wip_limit=wip_limit,
             is_system=False,
             is_active=True,
             project_id=project_id,
@@ -238,6 +242,9 @@ def edit_column(column_id):
         color = request.form.get("color", "secondary").strip()
         is_complete_state = request.form.get("is_complete_state") == "on"
         is_active = request.form.get("is_active") == "on"
+        wip_limit = request.form.get("wip_limit", type=int)
+        if not wip_limit or wip_limit < 1:
+            wip_limit = None
 
         # Validate required fields
         if not label:
@@ -250,6 +257,7 @@ def edit_column(column_id):
         column.color = color
         column.is_complete_state = is_complete_state
         column.is_active = is_active
+        column.wip_limit = wip_limit
 
         # Explicitly flush to write changes immediately
         try:

--- a/app/templates/kanban/columns.html
+++ b/app/templates/kanban/columns.html
@@ -51,6 +51,7 @@
               <th scope="col" class="px-4 py-3 w-28">{{ _('Color') }}</th>
               <th scope="col" class="px-4 py-3 w-28">{{ _('Status') }}</th>
               <th scope="col" class="px-4 py-3 w-32">{{ _('Complete?') }}</th>
+              <th scope="col" class="px-4 py-3 w-24">{{ _('WIP Limit') }}</th>
               <th scope="col" class="px-4 py-3 w-28">{{ _('System') }}</th>
               <th scope="col" class="px-4 py-3 w-52">{{ _('Actions') }}</th>
             </tr>
@@ -79,6 +80,13 @@
                   <span class="inline-flex items-center gap-1 text-sm text-green-700 dark:text-green-300"><i class="fas fa-check-circle"></i> {{ _('Yes') }}</span>
                 {% else %}
                   <span class="inline-flex items-center gap-1 text-sm text-text-muted-light dark:text-text-muted-dark"><i class="fas fa-circle"></i> {{ _('No') }}</span>
+                {% endif %}
+              </td>
+              <td class="px-4 py-3">
+                {% if column.wip_limit %}
+                  <span class="inline-flex items-center px-2 py-1 rounded text-xs bg-background-light dark:bg-background-dark border border-border-light dark:border-border-dark">{{ column.wip_limit }}</span>
+                {% else %}
+                  <span class="text-text-muted-light dark:text-text-muted-dark">&mdash;</span>
                 {% endif %}
               </td>
               <td class="px-4 py-3">

--- a/app/templates/kanban/create_column.html
+++ b/app/templates/kanban/create_column.html
@@ -72,6 +72,12 @@
           </div>
 
           <div class="mt-4">
+            <label for="wip_limit" class="block text-sm font-medium mb-1">{{ _('WIP Limit') }}</label>
+            <input type="number" id="wip_limit" name="wip_limit" min="1" step="1" placeholder="{{ _('No limit') }}" class="w-full md:w-48 rounded-lg border border-border-light dark:border-border-dark bg-background-light dark:bg-gray-700 px-3 py-2">
+            <p class="mt-1 text-xs text-text-muted-light dark:text-text-muted-dark">{{ _('Maximum number of tasks allowed in this column. Leave blank for no limit; the board flags the column when it is over.') }}</p>
+          </div>
+
+          <div class="mt-4">
             <div class="flex items-start gap-2">
               <input type="checkbox" id="is_complete_state" name="is_complete_state" class="mt-1" aria-describedby="completeHelp">
               <div>

--- a/app/templates/kanban/edit_column.html
+++ b/app/templates/kanban/edit_column.html
@@ -64,6 +64,12 @@
           </div>
 
           <div class="mt-4">
+            <label for="wip_limit" class="block text-sm font-medium mb-1">{{ _('WIP Limit') }}</label>
+            <input type="number" id="wip_limit" name="wip_limit" min="1" step="1" value="{{ column.wip_limit or '' }}" placeholder="{{ _('No limit') }}" class="w-full md:w-48 rounded-lg border border-border-light dark:border-border-dark bg-background-light dark:bg-gray-700 px-3 py-2">
+            <p class="mt-1 text-xs text-text-muted-light dark:text-text-muted-dark">{{ _('Maximum number of tasks allowed in this column. Leave blank for no limit; the board flags the column when it is over.') }}</p>
+          </div>
+
+          <div class="mt-4">
             <div class="flex items-start gap-2">
               <input type="checkbox" id="is_complete_state" name="is_complete_state" {% if column.is_complete_state %}checked{% endif %} class="mt-1" aria-describedby="completeHelp">
               <div>

--- a/app/templates/tasks/_kanban.html
+++ b/app/templates/tasks/_kanban.html
@@ -19,7 +19,9 @@
 
   <div id="kanbanBoard" class="kanban-board">
     {% for col in kanban_columns %}
-    <div class="kanban-column" data-status="{{ col.key }}" data-column-color="{{ col.color }}">
+    {% set col_count = tasks|selectattr('status', 'equalto', col.key)|list|length %}
+    {% set col_over_wip = col.wip_limit and col_count > col.wip_limit %}
+    <div class="kanban-column{% if col_over_wip %} kanban-column-over-wip{% endif %}" data-status="{{ col.key }}" data-column-color="{{ col.color }}"{% if col.wip_limit %} data-wip-limit="{{ col.wip_limit }}"{% endif %}>
       <div class="kanban-column-header">
         <div class="d-flex align-items-center justify-content-between">
           <div class="d-flex align-items-center gap-2">
@@ -28,8 +30,8 @@
             </div>
             <h6 class="kanban-column-title mb-0">{{ col.label }}</h6>
           </div>
-          <span class="kanban-count kanban-count-{{ col.key }}">
-            {{ tasks|selectattr('status', 'equalto', col.key)|list|length }}
+          <span class="kanban-count kanban-count-{{ col.key }}{% if col_over_wip %} kanban-count-over-wip{% endif %}"{% if col.wip_limit %} title="{{ _('WIP limit: %(limit)s', limit=col.wip_limit) }}"{% endif %}>
+            {{ col_count }}{% if col.wip_limit %} / {{ col.wip_limit }}{% endif %}
           </span>
         </div>
       </div>
@@ -274,6 +276,11 @@
 .kanban-count-in_progress { background: #fef3c7; color: #d97706; }
 .kanban-count-review { background: #dbeafe; color: #2563eb; }
 .kanban-count-done { background: #d1fae5; color: #059669; }
+
+/* WIP limit exceeded */
+.kanban-count-over-wip { background: #fee2e2 !important; color: #dc2626 !important; }
+.kanban-column-over-wip { box-shadow: inset 0 0 0 2px #f87171; }
+.kanban-column-over-wip .kanban-column-header { border-top: 3px solid #ef4444; }
 
 /* Column Body */
 .kanban-column-body {
@@ -857,7 +864,14 @@
       const body = col.querySelector('.kanban-column-body');
       const count = body ? body.querySelectorAll('.kanban-card').length : 0;
       const badge = col.querySelector('.kanban-count');
-      if (badge) badge.textContent = count;
+      const wipLimit = parseInt(col.dataset.wipLimit, 10);
+      const hasLimit = !isNaN(wipLimit) && wipLimit > 0;
+      const overWip = hasLimit && count > wipLimit;
+      if (badge) {
+        badge.textContent = hasLimit ? `${count} / ${wipLimit}` : count;
+        badge.classList.toggle('kanban-count-over-wip', overWip);
+      }
+      col.classList.toggle('kanban-column-over-wip', overWip);
     });
   }
 

--- a/migrations/versions/168_add_kanban_wip_limit.py
+++ b/migrations/versions/168_add_kanban_wip_limit.py
@@ -1,0 +1,35 @@
+"""Add wip_limit to kanban_columns for per-column work-in-progress limits.
+
+Revision ID: 168_add_kanban_wip_limit
+Revises: 167_merge_claude_attendance_heads
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+revision = "168_add_kanban_wip_limit"
+down_revision = "166_add_slack_user_id"
+branch_labels = None
+depends_on = None
+
+
+def _has_column(inspector, table_name: str, column_name: str) -> bool:
+    try:
+        return column_name in {c["name"] for c in inspector.get_columns(table_name)}
+    except Exception:
+        return False
+
+
+def upgrade():
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if not _has_column(inspector, "kanban_columns", "wip_limit"):
+        op.add_column("kanban_columns", sa.Column("wip_limit", sa.Integer(), nullable=True))
+
+
+def downgrade():
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if _has_column(inspector, "kanban_columns", "wip_limit"):
+        op.drop_column("kanban_columns", "wip_limit")

--- a/tests/test_kanban_wip_limit.py
+++ b/tests/test_kanban_wip_limit.py
@@ -1,0 +1,101 @@
+"""Per-column WIP (work-in-progress) limits on kanban columns."""
+
+import pytest
+
+from app import db
+from app.models import KanbanColumn
+
+pytestmark = [pytest.mark.integration, pytest.mark.routes]
+
+
+def test_wip_limit_defaults_to_none(app):
+    """A column created without a wip_limit stores NULL (no limit)."""
+    with app.app_context():
+        column = KanbanColumn(key="wip_none", label="WIP None", project_id=None)
+        db.session.add(column)
+        db.session.commit()
+        stored = KanbanColumn.get_column_by_key("wip_none", project_id=None)
+        assert stored.wip_limit is None
+
+
+def test_wip_limit_roundtrip_and_to_dict(app):
+    """A wip_limit value persists and is exposed through to_dict()."""
+    with app.app_context():
+        column = KanbanColumn(key="wip_three", label="WIP Three", project_id=None, wip_limit=3)
+        db.session.add(column)
+        db.session.commit()
+
+        stored = KanbanColumn.get_column_by_key("wip_three", project_id=None)
+        assert stored.wip_limit == 3
+        assert stored.to_dict()["wip_limit"] == 3
+
+
+def test_create_column_route_persists_wip_limit(app, admin_authenticated_client):
+    """POSTing the create form with a wip_limit stores it on the new column."""
+    resp = admin_authenticated_client.post(
+        "/kanban/columns/create",
+        data={"key": "blocked_wip", "label": "Blocked", "wip_limit": "5"},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    with app.app_context():
+        column = KanbanColumn.get_column_by_key("blocked_wip", project_id=None)
+        assert column is not None
+        assert column.wip_limit == 5
+
+
+def test_create_column_route_blank_wip_limit_is_none(app, admin_authenticated_client):
+    """A blank wip_limit field results in no limit (NULL)."""
+    resp = admin_authenticated_client.post(
+        "/kanban/columns/create",
+        data={"key": "nolimit_wip", "label": "No Limit", "wip_limit": ""},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    with app.app_context():
+        column = KanbanColumn.get_column_by_key("nolimit_wip", project_id=None)
+        assert column is not None
+        assert column.wip_limit is None
+
+
+def test_create_column_route_zero_wip_limit_is_none(app, admin_authenticated_client):
+    """A zero or negative wip_limit is normalized to no limit (NULL)."""
+    resp = admin_authenticated_client.post(
+        "/kanban/columns/create",
+        data={"key": "zero_wip", "label": "Zero", "wip_limit": "0"},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    with app.app_context():
+        column = KanbanColumn.get_column_by_key("zero_wip", project_id=None)
+        assert column is not None
+        assert column.wip_limit is None
+
+
+def test_edit_column_route_updates_wip_limit(app, admin_authenticated_client):
+    """Editing a column can set and later clear its wip_limit."""
+    with app.app_context():
+        column = KanbanColumn(key="edit_wip", label="Edit WIP", project_id=None)
+        db.session.add(column)
+        db.session.commit()
+        column_id = column.id
+
+    # Set a limit.
+    resp = admin_authenticated_client.post(
+        f"/kanban/columns/{column_id}/edit",
+        data={"label": "Edit WIP", "wip_limit": "7", "is_active": "on"},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    with app.app_context():
+        assert KanbanColumn.query.get(column_id).wip_limit == 7
+
+    # Clear the limit.
+    resp = admin_authenticated_client.post(
+        f"/kanban/columns/{column_id}/edit",
+        data={"label": "Edit WIP", "wip_limit": "", "is_active": "on"},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    with app.app_context():
+        assert KanbanColumn.query.get(column_id).wip_limit is None


### PR DESCRIPTION
## Summary

Adds an optional **per-column work-in-progress (WIP) limit** to kanban columns — a soft cap on how many cards a column should hold, surfaced on the board so teams can spot overloaded stages at a glance.

WIP limits are one of the core signals of a healthy kanban flow: they make bottlenecks visible and encourage finishing work before starting more. This brings TimeTracker's kanban in line with that expectation while staying fully optional and backward compatible.

## What changed

- **Model** (`app/models/kanban_column.py`): new nullable `wip_limit` integer column; included in `to_dict()`. `NULL` / unset = no limit (existing behavior).
- **Migration** (`168_add_kanban_wip_limit`): idempotent `add_column` guarded by table inspection; downgrade drops the column. Chains onto the current head (`166_add_slack_user_id`).
- **Routes** (`app/routes/kanban.py`): create/edit column endpoints read `wip_limit` from the form; blank or `0` normalizes to `NULL` (no limit).
- **Templates**: `create_column.html` / `edit_column.html` gain a numeric "WIP limit" field; `columns.html` shows the configured value; `_kanban.html` renders a per-column count badge that highlights when the card count meets or exceeds the limit.

## Behavior

- Fully opt-in — columns default to no limit, so existing boards are unchanged.
- The limit is a **visual signal**, not a hard block: cards can still be moved into a full column (matching how most kanban tools treat WIP limits), the column just flags that it's over its target.

## Test plan

- `tests/test_kanban_wip_limit.py` — 6 tests: model default is `NULL`, round-trip + `to_dict`, create/edit routes persist the value, and blank/`0` both normalize to `NULL`.
- `pytest tests/test_kanban_wip_limit.py` → 6 passed.
- `black --check -l 120` clean; `alembic heads` shows a single head (`166 → 168`).
