### PR TITLE
feat(kanban): add saveable board templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,4 +253,5 @@ mobile/.flutter-plugins-dependencies.lock.lock.lock.lock.lock.lock.lock.lock.loc
 .test_installation_config/
 
 ## License Files
-donate_hide_private.pem
+donate_hide_private.pemtasks/
+.claude/skills/

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -50,6 +50,7 @@ from .invoice_pdf_template import InvoicePDFTemplate
 from .invoice_peppol import InvoicePeppolTransmission
 from .invoice_template import InvoiceTemplate
 from .issue import Issue
+from .kanban_board_template import KanbanBoardTemplate
 from .kanban_column import KanbanColumn
 from .lead import Lead
 from .lead_activity import LeadActivity
@@ -134,6 +135,7 @@ __all__ = [
     "SavedReportView",
     "ReportEmailSchedule",
     "KanbanColumn",
+    "KanbanBoardTemplate",
     "TimeEntryTemplate",
     "Activity",
     "UserFavoriteProject",

--- a/app/models/kanban_board_template.py
+++ b/app/models/kanban_board_template.py
@@ -1,0 +1,132 @@
+from app import db
+from app.utils.timezone import now_in_app_timezone
+
+# Fields copied from a KanbanColumn into a template snapshot. is_system is
+# deliberately excluded: applying a template always creates user-owned
+# (non-system) columns.
+_COLUMN_SPEC_FIELDS = (
+    "key",
+    "label",
+    "icon",
+    "color",
+    "position",
+    "is_complete_state",
+)
+
+# Column attributes captured only when the running schema actually has them, so
+# templates stay decoupled from optional features that add columns to
+# KanbanColumn (e.g. per-column WIP limits).
+_OPTIONAL_COLUMN_SPEC_FIELDS = ("wip_limit",)
+
+
+class KanbanBoardTemplate(db.Model):
+    """A saved, reusable snapshot of a set of kanban columns.
+
+    Templates let an admin capture the column layout of one board (global or
+    project-specific) and re-apply it to other projects, so teams don't have
+    to hand-build the same "To Do / In Progress / Review / Done" structure
+    over and over.
+    """
+
+    __tablename__ = "kanban_board_templates"
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=False, unique=True)
+    description = db.Column(db.String(255), nullable=True)
+    # Ordered list of column spec dicts (see _COLUMN_SPEC_FIELDS).
+    columns = db.Column(db.JSON, nullable=False, default=list)
+    created_by = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True, index=True)
+    created_at = db.Column(db.DateTime, default=now_in_app_timezone, nullable=False)
+    updated_at = db.Column(
+        db.DateTime,
+        default=now_in_app_timezone,
+        onupdate=now_in_app_timezone,
+        nullable=False,
+    )
+
+    creator = db.relationship("User")
+
+    def __repr__(self):
+        return f"<KanbanBoardTemplate {self.name!r} cols={len(self.columns or [])}>"
+
+    @property
+    def column_count(self):
+        """Number of columns captured in this template."""
+        return len(self.columns or [])
+
+    @staticmethod
+    def spec_from_column(column):
+        """Build a template column-spec dict from a KanbanColumn instance."""
+        spec = {field: getattr(column, field) for field in _COLUMN_SPEC_FIELDS}
+        for field in _OPTIONAL_COLUMN_SPEC_FIELDS:
+            if hasattr(column, field):
+                spec[field] = getattr(column, field)
+        return spec
+
+    @classmethod
+    def from_columns(cls, name, columns, description=None, created_by=None):
+        """Create a template capturing the given ordered KanbanColumn list."""
+        specs = [cls.spec_from_column(col) for col in columns]
+        return cls(
+            name=name.strip(),
+            description=(description or None),
+            columns=specs,
+            created_by=created_by,
+        )
+
+    def apply_to_project(self, project_id=None, replace=False):
+        """Materialize this template's columns for the given project scope.
+
+        project_id=None targets the global columns. When replace is True the
+        scope's existing columns are removed first; otherwise columns whose
+        key already exists in the scope are skipped so no unique constraint is
+        violated.
+
+        Returns the number of columns created.
+        """
+        from app.models import KanbanColumn
+
+        if replace:
+            existing = KanbanColumn.get_all_columns(project_id=project_id)
+            for col in existing:
+                db.session.delete(col)
+            db.session.flush()
+            existing_keys = set()
+        else:
+            existing_keys = {col.key for col in KanbanColumn.get_all_columns(project_id=project_id)}
+
+        created = 0
+        for position, spec in enumerate(self.columns or []):
+            key = spec.get("key")
+            if not key or key in existing_keys:
+                continue
+            column = KanbanColumn(
+                key=key,
+                label=spec.get("label") or key,
+                icon=spec.get("icon") or "fas fa-circle",
+                color=spec.get("color") or "secondary",
+                position=spec.get("position", position),
+                is_complete_state=bool(spec.get("is_complete_state")),
+                is_system=False,
+                is_active=True,
+                project_id=project_id,
+            )
+            for field in _OPTIONAL_COLUMN_SPEC_FIELDS:
+                if field in spec and hasattr(KanbanColumn, field):
+                    setattr(column, field, spec.get(field))
+            db.session.add(column)
+            existing_keys.add(key)
+            created += 1
+        return created
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "columns": self.columns or [],
+            "column_count": self.column_count,
+            "created_by": self.created_by,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/app/routes/kanban.py
+++ b/app/routes/kanban.py
@@ -3,7 +3,7 @@ from flask_babel import gettext as _
 from flask_login import current_user, login_required
 
 from app import db, socketio
-from app.models import KanbanColumn, Task
+from app.models import KanbanBoardTemplate, KanbanColumn, Task
 from app.utils.db import safe_commit
 from app.utils.module_helpers import module_enabled
 from app.utils.permissions import admin_or_permission_required
@@ -110,8 +110,17 @@ def list_columns():
 
     projects = Project.query.filter_by(status="active").order_by(Project.name).all()
 
+    # Saved board templates for the save/apply toolbar
+    templates = KanbanBoardTemplate.query.order_by(KanbanBoardTemplate.name.asc()).all()
+
     # Prevent browser caching
-    response = render_template("kanban/columns.html", columns=columns, projects=projects, project_id=project_id)
+    response = render_template(
+        "kanban/columns.html",
+        columns=columns,
+        projects=projects,
+        project_id=project_id,
+        templates=templates,
+    )
     resp = make_response(response)
     resp.headers["Cache-Control"] = "no-cache, no-store, must-revalidate, max-age=0"
     resp.headers["Pragma"] = "no-cache"
@@ -484,3 +493,113 @@ def api_list_columns():
     except Exception:
         pass
     return response
+
+
+# ---------------------------------------------------------------------------
+# Board templates: save a column layout and re-apply it to other projects
+# ---------------------------------------------------------------------------
+
+
+@kanban_bp.route("/kanban/templates")
+@login_required
+@module_enabled("kanban")
+@admin_or_permission_required("manage_kanban")
+def list_templates():
+    """List saved board templates."""
+    templates = KanbanBoardTemplate.query.order_by(KanbanBoardTemplate.name.asc()).all()
+    response = make_response(render_template("kanban/templates.html", templates=templates))
+    response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate, max-age=0"
+    return response
+
+
+@kanban_bp.route("/kanban/templates/save", methods=["POST"])
+@login_required
+@module_enabled("kanban")
+@admin_or_permission_required("manage_kanban")
+def save_template():
+    """Save the current columns of a scope (project or global) as a template."""
+    name = (request.form.get("name") or "").strip()
+    description = (request.form.get("description") or "").strip() or None
+    project_id = request.form.get("project_id", type=int) or None
+
+    if not name:
+        flash(_("Template name is required"), "error")
+        return redirect(
+            url_for("kanban.list_columns", project_id=project_id) if project_id else url_for("kanban.list_columns")
+        )
+
+    if KanbanBoardTemplate.query.filter(db.func.lower(KanbanBoardTemplate.name) == name.lower()).first():
+        flash(_("A template with that name already exists"), "error")
+        return redirect(
+            url_for("kanban.list_columns", project_id=project_id) if project_id else url_for("kanban.list_columns")
+        )
+
+    columns = KanbanColumn.get_all_columns(project_id=project_id)
+    if not columns:
+        flash(_("There are no columns to save for this board"), "error")
+        return redirect(
+            url_for("kanban.list_columns", project_id=project_id) if project_id else url_for("kanban.list_columns")
+        )
+
+    template = KanbanBoardTemplate.from_columns(
+        name=name, columns=columns, description=description, created_by=current_user.id
+    )
+    db.session.add(template)
+    if not safe_commit("save_kanban_template", {"name": name}):
+        flash(_("Could not save template due to a database error. Please check server logs."), "error")
+        return redirect(
+            url_for("kanban.list_columns", project_id=project_id) if project_id else url_for("kanban.list_columns")
+        )
+
+    flash(_('Template "%(name)s" saved with %(count)d columns', name=name, count=len(columns)), "success")
+    return redirect(url_for("kanban.list_templates"))
+
+
+@kanban_bp.route("/kanban/templates/<int:template_id>/apply", methods=["POST"])
+@login_required
+@module_enabled("kanban")
+@admin_or_permission_required("manage_kanban")
+def apply_template(template_id):
+    """Apply a template's columns to a project (or the global board)."""
+    template = KanbanBoardTemplate.query.get_or_404(template_id)
+    project_id = request.form.get("project_id", type=int) or None
+    replace = request.form.get("replace") in ("on", "1", "true", "yes")
+
+    created = template.apply_to_project(project_id=project_id, replace=replace)
+    if not safe_commit("apply_kanban_template", {"template_id": template_id, "project_id": project_id}):
+        flash(_("Could not apply template due to a database error. Please check server logs."), "error")
+        return redirect(url_for("kanban.list_templates"))
+
+    db.session.expire_all()
+    try:
+        socketio.emit(
+            "kanban_columns_updated",
+            {"action": "template_applied", "template_id": template_id, "project_id": project_id},
+            broadcast=True,
+        )
+    except Exception as e:
+        print(f"[KANBAN] Failed to emit event: {e}")
+
+    if created:
+        flash(_("Applied template: %(count)d columns added", count=created), "success")
+    else:
+        flash(_("Template applied; no new columns were needed"), "info")
+    return redirect(
+        url_for("kanban.list_columns", project_id=project_id) if project_id else url_for("kanban.list_columns")
+    )
+
+
+@kanban_bp.route("/kanban/templates/<int:template_id>/delete", methods=["POST"])
+@login_required
+@module_enabled("kanban")
+@admin_or_permission_required("manage_kanban")
+def delete_template(template_id):
+    """Delete a saved board template."""
+    template = KanbanBoardTemplate.query.get_or_404(template_id)
+    name = template.name
+    db.session.delete(template)
+    if not safe_commit("delete_kanban_template", {"template_id": template_id}):
+        flash(_("Could not delete template due to a database error. Please check server logs."), "error")
+        return redirect(url_for("kanban.list_templates"))
+    flash(_('Template "%(name)s" deleted', name=name), "success")
+    return redirect(url_for("kanban.list_templates"))

--- a/app/templates/kanban/columns.html
+++ b/app/templates/kanban/columns.html
@@ -37,6 +37,45 @@
       </div>
     </div>
 
+    <!-- Board templates toolbar -->
+    <div class="mb-6 bg-card-light dark:bg-card-dark rounded-xl shadow ring-1 ring-border-light/60 dark:ring-border-dark/60 p-4">
+      <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <div class="flex items-start gap-2">
+          <i class="fas fa-layer-group mt-1 text-primary"></i>
+          <div>
+            <div class="font-semibold">{{ _('Board Templates') }}</div>
+            <p class="text-sm text-text-muted-light dark:text-text-muted-dark">{{ _('Save this column layout as a reusable template, or apply an existing one to this board.') }}</p>
+          </div>
+        </div>
+        <div class="flex flex-wrap items-center gap-2">
+          {% if templates %}
+          <form method="POST" action="{{ url_for('kanban.apply_template', template_id=0) }}" id="applyTemplateForm" class="flex items-center gap-2">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            {% if project_id %}<input type="hidden" name="project_id" value="{{ project_id }}">{% endif %}
+            <select id="applyTemplateSelect" class="rounded-lg border border-border-light dark:border-border-dark bg-background-light dark:bg-gray-700 px-3 py-2 text-sm" aria-label="{{ _('Choose a template to apply') }}">
+              <option value="">{{ _('Apply template…') }}</option>
+              {% for template in templates %}
+              <option value="{{ template.id }}">{{ template.name }} ({{ template.column_count }})</option>
+              {% endfor %}
+            </select>
+            <label class="inline-flex items-center gap-1 text-sm text-text-muted-light dark:text-text-muted-dark" title="{{ _('Delete existing columns before applying') }}">
+              <input type="checkbox" name="replace" value="1" class="rounded border-border-light dark:border-border-dark"> {{ _('Replace') }}
+            </label>
+            <button type="submit" class="inline-flex items-center gap-2 px-3 py-2 rounded-lg border border-border-light dark:border-border-dark hover:bg-background-light dark:hover:bg-background-dark text-sm">
+              <i class="fas fa-check"></i> {{ _('Apply') }}
+            </button>
+          </form>
+          {% endif %}
+          <button type="button" onclick="showSaveTemplateModal()" class="inline-flex items-center gap-2 px-3 py-2 rounded-lg border border-border-light dark:border-border-dark hover:bg-background-light dark:hover:bg-background-dark text-sm">
+            <i class="fas fa-save"></i> {{ _('Save as Template') }}
+          </button>
+          <a href="{{ url_for('kanban.list_templates') }}" class="inline-flex items-center gap-2 px-3 py-2 rounded-lg border border-border-light dark:border-border-dark hover:bg-background-light dark:hover:bg-background-dark text-sm">
+            <i class="fas fa-cog"></i> {{ _('Manage') }}
+          </a>
+        </div>
+      </div>
+    </div>
+
     <!-- Flash messages are globally converted to toasts in base.html -->
 
     <div class="bg-card-light dark:bg-card-dark rounded-xl shadow ring-1 ring-border-light/60 dark:ring-border-dark/60">
@@ -132,6 +171,42 @@
   </div>
 </div>
 
+<!-- Save Template Modal -->
+<div id="saveTemplateModal" class="hidden fixed inset-0 z-50" role="dialog" aria-modal="true" aria-labelledby="saveTemplateTitle">
+  <div class="absolute inset-0 bg-black/50" onclick="hideSaveTemplateModal()"></div>
+  <div class="relative max-w-lg mx-auto mt-24 bg-card-light dark:bg-card-dark text-text-light dark:text-text-dark rounded-lg shadow-xl ring-1 ring-border-light/60 dark:ring-border-dark/60">
+    <form method="POST" action="{{ url_for('kanban.save_template') }}">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      {% if project_id %}<input type="hidden" name="project_id" value="{{ project_id }}">{% endif %}
+      <div class="p-4 border-b border-border-light dark:border-border-dark flex items-center justify-between">
+        <h5 id="saveTemplateTitle" class="text-lg font-semibold flex items-center gap-2">
+          <i class="fas fa-save text-primary"></i> {{ _('Save Board Template') }}
+        </h5>
+        <button type="button" class="px-2 py-1 hover:bg-background-light dark:hover:bg-background-dark rounded" aria-label="{{ _('Close') }}" onclick="hideSaveTemplateModal()">&times;</button>
+      </div>
+      <div class="p-4 space-y-4">
+        <p class="text-sm text-text-muted-light dark:text-text-muted-dark">{{ _('Captures the current %(count)d column(s) so you can re-apply this layout to other boards.', count=columns|length) }}</p>
+        <div>
+          <label for="templateName" class="block text-sm font-medium mb-1">{{ _('Template name') }} <span class="text-danger">*</span></label>
+          <input type="text" id="templateName" name="name" required maxlength="100" class="w-full rounded-lg border border-border-light dark:border-border-dark bg-background-light dark:bg-gray-700 px-3 py-2" placeholder="{{ _('e.g. Standard Delivery Board') }}">
+        </div>
+        <div>
+          <label for="templateDescription" class="block text-sm font-medium mb-1">{{ _('Description') }}</label>
+          <input type="text" id="templateDescription" name="description" maxlength="255" class="w-full rounded-lg border border-border-light dark:border-border-dark bg-background-light dark:bg-gray-700 px-3 py-2" placeholder="{{ _('Optional') }}">
+        </div>
+      </div>
+      <div class="p-4 border-t border-border-light dark:border-border-dark flex items-center justify-between">
+        <button type="button" class="inline-flex items-center gap-2 px-3 py-2 rounded border border-border-light dark:border-border-dark hover:bg-background-light dark:hover:bg-background-dark" onclick="hideSaveTemplateModal()">
+          <i class="fas fa-times"></i> {{ _('Cancel') }}
+        </button>
+        <button type="submit" class="inline-flex items-center gap-2 px-3 py-2 rounded bg-primary text-white hover:opacity-90">
+          <i class="fas fa-save"></i> {{ _('Save Template') }}
+        </button>
+      </div>
+    </form>
+  </div>
+</div>
+
 <!-- Delete Column Modal -->
 <div id="deleteColumnModal" class="hidden fixed inset-0 z-50" role="dialog" aria-modal="true" aria-labelledby="deleteModalTitle">
   <div class="absolute inset-0 bg-black/50" onclick="hideDeleteModal()"></div>
@@ -188,9 +263,37 @@ function hideDeleteModal(){
   if (modal) modal.classList.add('hidden');
 }
 
+// Save-as-template modal
+function showSaveTemplateModal(){
+  const modal = document.getElementById('saveTemplateModal');
+  if (modal) modal.classList.remove('hidden');
+  const nameEl = document.getElementById('templateName');
+  if (nameEl) nameEl.focus();
+}
+
+function hideSaveTemplateModal(){
+  const modal = document.getElementById('saveTemplateModal');
+  if (modal) modal.classList.add('hidden');
+}
+
+// Point the apply form at the selected template before submitting
+const applyForm = document.getElementById('applyTemplateForm');
+if (applyForm) {
+  applyForm.addEventListener('submit', function(e){
+    const select = document.getElementById('applyTemplateSelect');
+    const templateId = select ? select.value : '';
+    if (!templateId) {
+      e.preventDefault();
+      try { showToast('{{ _('Please choose a template to apply.') }}', 'error'); } catch(_) { alert('{{ _('Please choose a template to apply.') }}'); }
+      return;
+    }
+    applyForm.action = "{{ url_for('kanban.apply_template', template_id=0) }}".replace('0', templateId);
+  });
+}
+
 // Close on Escape
 document.addEventListener('keydown', function(e){
-  if (e.key === 'Escape') hideDeleteModal();
+  if (e.key === 'Escape') { hideDeleteModal(); hideSaveTemplateModal(); }
 });
 
 // Enable drag-and-drop reordering

--- a/app/templates/kanban/templates.html
+++ b/app/templates/kanban/templates.html
@@ -1,0 +1,115 @@
+{% extends "base.html" %}
+{% block title %}{{ _('Kanban Board Templates') }}{% endblock %}
+
+{% block head_extra %}
+<!-- Prevent page caching -->
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate, max-age=0">
+<meta http-equiv="Pragma" content="no-cache">
+<meta http-equiv="Expires" content="0">
+{% endblock %}
+
+{% block content %}
+<div class="px-4 sm:px-6 lg:px-8">
+  <div class="max-w-6xl mx-auto">
+    <div class="flex items-center justify-between mb-6">
+      <div>
+        <h2 class="text-2xl font-bold flex items-center gap-2">
+          <span class="w-9 h-9 rounded-lg bg-primary flex items-center justify-center text-white"><i class="fas fa-layer-group"></i></span>
+          {{ _('Kanban Board Templates') }}
+        </h2>
+        <p class="text-text-muted-light dark:text-text-muted-dark">{{ _('Reusable column layouts you can apply to any board') }}</p>
+      </div>
+      <a href="{{ url_for('kanban.list_columns') }}" class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-border-light dark:border-border-dark hover:bg-background-light dark:hover:bg-background-dark">
+        <i class="fas fa-columns"></i> {{ _('Manage Columns') }}
+      </a>
+    </div>
+
+    <div class="bg-card-light dark:bg-card-dark rounded-xl shadow ring-1 ring-border-light/60 dark:ring-border-dark/60">
+      <div class="p-0 overflow-x-auto">
+        <table class="min-w-full divide-y divide-border-light dark:divide-border-dark" role="table" aria-label="{{ _('Board templates list') }}">
+          <thead>
+            <tr class="text-left text-sm">
+              <th scope="col" class="px-4 py-3">{{ _('Name') }}</th>
+              <th scope="col" class="px-4 py-3">{{ _('Description') }}</th>
+              <th scope="col" class="px-4 py-3 w-28">{{ _('Columns') }}</th>
+              <th scope="col" class="px-4 py-3 w-32">{{ _('Actions') }}</th>
+            </tr>
+          </thead>
+          <tbody role="rowgroup">
+            {% for template in templates %}
+            <tr role="row">
+              <td class="px-4 py-3"><strong>{{ template.name }}</strong></td>
+              <td class="px-4 py-3 text-text-muted-light dark:text-text-muted-dark">{{ template.description or '—' }}</td>
+              <td class="px-4 py-3">
+                <span class="inline-flex items-center px-2 py-1 rounded text-xs bg-background-light dark:bg-background-dark border border-border-light dark:border-border-dark">{{ template.column_count }}</span>
+              </td>
+              <td class="px-4 py-3">
+                <button type="button" class="inline-flex items-center gap-1 px-2 py-1 rounded border border-red-300 text-red-700 hover:bg-red-50 dark:hover:bg-red-900/30" title="{{ _('Delete') }}" onclick="showDeleteTemplateModal({{ template.id }}, '{{ template.name|replace("'", "\\'") }}')">
+                  <i class="fas fa-trash"></i>
+                </button>
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+
+      {% if not templates %}
+      <div class="text-center py-8">
+        <i class="fas fa-layer-group fa-3x text-text-muted-light dark:text-text-muted-dark mb-3"></i>
+        <p class="text-text-muted-light dark:text-text-muted-dark">{{ _('No board templates yet. Save a column layout from the Manage Columns page to create one.') }}</p>
+      </div>
+      {% endif %}
+    </div>
+  </div>
+</div>
+
+<!-- Delete Template Modal -->
+<div id="deleteTemplateModal" class="hidden fixed inset-0 z-50" role="dialog" aria-modal="true" aria-labelledby="deleteTemplateTitle">
+  <div class="absolute inset-0 bg-black/50" onclick="hideDeleteTemplateModal()"></div>
+  <div class="relative max-w-lg mx-auto mt-24 bg-card-light dark:bg-card-dark text-text-light dark:text-text-dark rounded-lg shadow-xl ring-1 ring-border-light/60 dark:ring-border-dark/60">
+    <div class="p-4 border-b border-border-light dark:border-border-dark flex items-center justify-between">
+      <h5 id="deleteTemplateTitle" class="text-lg font-semibold flex items-center gap-2">
+        <i class="fas fa-trash text-danger"></i> {{ _('Delete Board Template') }}
+      </h5>
+      <button type="button" class="px-2 py-1 hover:bg-background-light dark:hover:bg-background-dark rounded" aria-label="{{ _('Close') }}" onclick="hideDeleteTemplateModal()">&times;</button>
+    </div>
+    <div class="p-4">
+      <p>{{ _('Are you sure you want to delete this template?') }}</p>
+      <p class="text-text-muted-light dark:text-text-muted-dark mt-2"><small id="deleteTemplateName"></small></p>
+      <p class="text-text-muted-light dark:text-text-muted-dark mt-2"><small>{{ _('Existing boards are not affected; only the saved layout is removed.') }}</small></p>
+    </div>
+    <div class="p-4 border-t border-border-light dark:border-border-dark flex items-center justify-between">
+      <button type="button" class="inline-flex items-center gap-2 px-3 py-2 rounded border border-border-light dark:border-border-dark hover:bg-background-light dark:hover:bg-background-dark" onclick="hideDeleteTemplateModal()">
+        <i class="fas fa-times"></i> {{ _('Cancel') }}
+      </button>
+      <form method="POST" id="deleteTemplateForm" class="inline">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <button type="submit" class="inline-flex items-center gap-2 px-3 py-2 rounded bg-danger text-white hover:opacity-90">
+          <i class="fas fa-trash"></i> {{ _('Delete Template') }}
+        </button>
+      </form>
+    </div>
+  </div>
+</div>
+
+<script>
+function showDeleteTemplateModal(templateId, name){
+  const nameEl = document.getElementById('deleteTemplateName');
+  const formEl = document.getElementById('deleteTemplateForm');
+  if (nameEl) nameEl.textContent = name || '';
+  if (formEl) formEl.action = "{{ url_for('kanban.delete_template', template_id=0) }}".replace('0', templateId);
+  const modal = document.getElementById('deleteTemplateModal');
+  if (modal) modal.classList.remove('hidden');
+}
+
+function hideDeleteTemplateModal(){
+  const modal = document.getElementById('deleteTemplateModal');
+  if (modal) modal.classList.add('hidden');
+}
+
+document.addEventListener('keydown', function(e){
+  if (e.key === 'Escape') hideDeleteTemplateModal();
+});
+</script>
+{% endblock %}

--- a/migrations/versions/170_add_kanban_board_templates.py
+++ b/migrations/versions/170_add_kanban_board_templates.py
@@ -1,0 +1,51 @@
+"""Add kanban_board_templates table for saveable board layouts.
+
+Revision ID: 170_add_kanban_board_templates
+Revises: 169_add_task_checklist_items
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+revision = "170_add_kanban_board_templates"
+down_revision = "166_add_slack_user_id"
+branch_labels = None
+depends_on = None
+
+
+def _has_table(inspector, table_name: str) -> bool:
+    try:
+        return table_name in inspector.get_table_names()
+    except Exception:
+        return False
+
+
+def upgrade():
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if _has_table(inspector, "kanban_board_templates"):
+        return
+    op.create_table(
+        "kanban_board_templates",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("description", sa.String(length=255), nullable=True),
+        sa.Column("columns", sa.JSON(), nullable=False),
+        sa.Column("created_by", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["created_by"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name", name="uq_kanban_board_template_name"),
+    )
+    op.create_index("ix_kanban_board_templates_created_by", "kanban_board_templates", ["created_by"])
+
+
+def downgrade():
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if not _has_table(inspector, "kanban_board_templates"):
+        return
+    op.drop_index("ix_kanban_board_templates_created_by", table_name="kanban_board_templates")
+    op.drop_table("kanban_board_templates")

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,3 @@
+# Lessons Learned
+
+<!-- Record corrections and patterns to avoid repeating mistakes. -->

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,3 @@
+# TODO
+
+<!-- Track current work items here. Check items off as you complete them. -->

--- a/tests/test_kanban_board_template.py
+++ b/tests/test_kanban_board_template.py
@@ -1,0 +1,251 @@
+"""Saveable kanban board templates (capture a column layout, re-apply it)."""
+
+import pytest
+
+from app import db
+from app.models import KanbanBoardTemplate, KanbanColumn
+
+pytestmark = [pytest.mark.integration, pytest.mark.routes]
+
+
+def _make_columns(project_id, specs):
+    """Create and persist KanbanColumn rows for a scope; return them ordered."""
+    for position, spec in enumerate(specs):
+        db.session.add(
+            KanbanColumn(
+                key=spec["key"],
+                label=spec.get("label", spec["key"].title()),
+                icon=spec.get("icon", "fas fa-circle"),
+                color=spec.get("color", "secondary"),
+                position=position,
+                is_complete_state=spec.get("is_complete_state", False),
+                project_id=project_id,
+            )
+        )
+    db.session.commit()
+    return KanbanColumn.get_all_columns(project_id=project_id)
+
+
+def test_spec_from_column_captures_fields(app):
+    """spec_from_column snapshots exactly the template spec fields."""
+    with app.app_context():
+        col = KanbanColumn(
+            key="review",
+            label="Review",
+            icon="fas fa-eye",
+            color="warning",
+            position=2,
+            is_complete_state=False,
+            project_id=None,
+        )
+        spec = KanbanBoardTemplate.spec_from_column(col)
+        assert spec == {
+            "key": "review",
+            "label": "Review",
+            "icon": "fas fa-eye",
+            "color": "warning",
+            "position": 2,
+            "is_complete_state": False,
+        }
+
+
+def test_from_columns_and_to_dict(app):
+    """from_columns snapshots the ordered columns; to_dict exposes the count."""
+    with app.app_context():
+        cols = _make_columns(
+            project_id=None,
+            specs=[
+                {"key": "tpl_todo", "label": "To Do"},
+                {"key": "tpl_done", "label": "Done", "is_complete_state": True},
+            ],
+        )
+        template = KanbanBoardTemplate.from_columns(
+            name="Basic", columns=cols, description="Two columns", created_by=None
+        )
+        db.session.add(template)
+        db.session.commit()
+
+        d = template.to_dict()
+        assert d["name"] == "Basic"
+        assert d["description"] == "Two columns"
+        assert d["column_count"] == 2
+        assert [c["key"] for c in d["columns"]] == ["tpl_todo", "tpl_done"]
+
+
+def test_apply_to_project_creates_columns(app, project):
+    """Applying a template to an empty scope creates all its columns."""
+    pid = project.id
+    with app.app_context():
+        template = KanbanBoardTemplate(
+            name="Delivery",
+            columns=[
+                {"key": "a_backlog", "label": "Backlog", "position": 0},
+                {
+                    "key": "a_done",
+                    "label": "Done",
+                    "is_complete_state": True,
+                    "position": 1,
+                },
+            ],
+        )
+        db.session.add(template)
+        db.session.commit()
+
+        created = template.apply_to_project(project_id=pid)
+        db.session.commit()
+
+        assert created == 2
+        cols = KanbanColumn.get_all_columns(project_id=pid)
+        assert {c.key for c in cols} == {"a_backlog", "a_done"}
+        done = KanbanColumn.get_column_by_key("a_done", project_id=pid)
+        assert done.is_complete_state is True
+        assert done.is_system is False
+
+
+def test_apply_to_project_skips_existing_keys(app, project):
+    """Without replace, columns whose key already exists are skipped."""
+    pid = project.id
+    with app.app_context():
+        _make_columns(project_id=pid, specs=[{"key": "keep_me", "label": "Keep"}])
+        template = KanbanBoardTemplate(
+            name="Overlap",
+            columns=[
+                {"key": "keep_me", "label": "Renamed"},
+                {"key": "brand_new", "label": "New"},
+            ],
+        )
+        db.session.add(template)
+        db.session.commit()
+
+        created = template.apply_to_project(project_id=pid)
+        db.session.commit()
+
+        assert created == 1
+        cols = KanbanColumn.get_all_columns(project_id=pid)
+        assert {c.key for c in cols} == {"keep_me", "brand_new"}
+        # Existing column untouched (label not overwritten).
+        assert KanbanColumn.get_column_by_key("keep_me", project_id=pid).label == "Keep"
+
+
+def test_apply_to_project_replace_wipes_existing(app, project):
+    """With replace=True, the scope's existing columns are removed first."""
+    pid = project.id
+    with app.app_context():
+        _make_columns(project_id=pid, specs=[{"key": "old_one", "label": "Old"}])
+        template = KanbanBoardTemplate(
+            name="Replacement",
+            columns=[{"key": "fresh", "label": "Fresh"}],
+        )
+        db.session.add(template)
+        db.session.commit()
+
+        created = template.apply_to_project(project_id=pid, replace=True)
+        db.session.commit()
+
+        assert created == 1
+        cols = KanbanColumn.get_all_columns(project_id=pid)
+        assert {c.key for c in cols} == {"fresh"}
+
+
+def test_save_template_route_persists(app, admin_authenticated_client, project):
+    """POSTing the save form captures the current columns as a template."""
+    pid = project.id
+    with app.app_context():
+        _make_columns(project_id=pid, specs=[{"key": "s_todo"}, {"key": "s_done"}])
+
+    resp = admin_authenticated_client.post(
+        "/kanban/templates/save",
+        data={
+            "name": "Route Template",
+            "description": "via route",
+            "project_id": str(pid),
+        },
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    with app.app_context():
+        template = KanbanBoardTemplate.query.filter_by(name="Route Template").first()
+        assert template is not None
+        assert template.column_count == 2
+        assert {c["key"] for c in template.columns} == {"s_todo", "s_done"}
+
+
+def test_save_template_route_requires_name(app, admin_authenticated_client):
+    """A blank name does not create a template."""
+    resp = admin_authenticated_client.post(
+        "/kanban/templates/save",
+        data={"name": "", "project_id": ""},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    with app.app_context():
+        assert KanbanBoardTemplate.query.count() == 0
+
+
+def test_save_template_route_rejects_duplicate_name(app, admin_authenticated_client, project):
+    """A case-insensitive duplicate name is rejected."""
+    pid = project.id
+    with app.app_context():
+        _make_columns(project_id=pid, specs=[{"key": "d_todo"}])
+        db.session.add(KanbanBoardTemplate(name="Dupe", columns=[{"key": "x"}]))
+        db.session.commit()
+
+    resp = admin_authenticated_client.post(
+        "/kanban/templates/save",
+        data={"name": "dupe", "project_id": str(pid)},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    with app.app_context():
+        assert KanbanBoardTemplate.query.filter(db.func.lower(KanbanBoardTemplate.name) == "dupe").count() == 1
+
+
+def test_apply_template_route(app, admin_authenticated_client, project):
+    """POSTing apply materializes the template's columns into a scope."""
+    pid = project.id
+    with app.app_context():
+        template = KanbanBoardTemplate(
+            name="Applier",
+            columns=[{"key": "ap_a", "position": 0}, {"key": "ap_b", "position": 1}],
+        )
+        db.session.add(template)
+        db.session.commit()
+        template_id = template.id
+
+    resp = admin_authenticated_client.post(
+        f"/kanban/templates/{template_id}/apply",
+        data={"project_id": str(pid)},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    with app.app_context():
+        cols = KanbanColumn.get_all_columns(project_id=pid)
+        assert {c.key for c in cols} == {"ap_a", "ap_b"}
+
+
+def test_delete_template_route(app, admin_authenticated_client):
+    """POSTing delete removes the template."""
+    with app.app_context():
+        template = KanbanBoardTemplate(name="Trash Me", columns=[{"key": "t"}])
+        db.session.add(template)
+        db.session.commit()
+        template_id = template.id
+
+    resp = admin_authenticated_client.post(
+        f"/kanban/templates/{template_id}/delete",
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    with app.app_context():
+        assert KanbanBoardTemplate.query.get(template_id) is None
+
+
+def test_list_templates_route_renders(app, admin_authenticated_client):
+    """The management page lists saved templates."""
+    with app.app_context():
+        db.session.add(KanbanBoardTemplate(name="Listed Template", columns=[{"key": "l"}]))
+        db.session.commit()
+
+    resp = admin_authenticated_client.get("/kanban/templates")
+    assert resp.status_code == 200
+    assert b"Listed Template" in resp.data


### PR DESCRIPTION
## Summary

Adds **saveable kanban board templates** — capture the column layout of one board (global or project-specific) as a named, reusable template, then apply it to other projects so teams don't hand-rebuild the same "To Do / In Progress / Review / Done" structure every time.

## What changed

- **Model** (`app/models/kanban_board_template.py`): new `KanbanBoardTemplate` storing a name, optional description, and an ordered JSON list of column specs. `spec_from_column` / `from_columns` snapshot a live column set; `apply_to_project(project_id, replace=)` materializes the columns into a scope, skipping keys that already exist (or wiping first when `replace=True`). Registered in `app/models/__init__.py`.
- **Migration** (`170_add_kanban_board_templates`): idempotent `create_table` guarded by table inspection; downgrade drops it. Chains onto the current head (`166_add_slack_user_id`).
- **Routes** (`app/routes/kanban.py`): admin-scoped save / apply / delete endpoints and a `GET /kanban/templates` listing page. The columns page gains a "Save as template" action.
- **Templates**: new `kanban/templates.html` management view; save/apply controls wired into `kanban/columns.html`.

## Design note

The column snapshot is **forward-compatible with optional column features**: any extra column attribute (e.g. a per-column WIP limit) is captured and re-applied only when the running schema actually has that column, via a small `_OPTIONAL_COLUMN_SPEC_FIELDS` guard. This keeps templates working whether or not those features are present — no hard dependency.

## Behavior

- Admin-only; regular users are unaffected.
- Applying a template never clobbers columns by default (key-collision skip); `replace` is opt-in.

## Test plan

- `tests/test_kanban_board_template.py` — 11 tests: spec snapshotting, `from_columns` + `to_dict`, apply (create / skip-existing / replace), and the save / apply / delete / list / validation routes.
- `pytest tests/test_kanban_board_template.py` → 11 passed.
- `black --check -l 120` clean; `alembic heads` shows a single head (`166 → 170`).

> Note: one of a small series of independent kanban PRs. If a sibling PR that also adds a migration lands first, this migration's `down_revision` may need a one-line bump to the new head — happy to rebase on request.
