### PR TITLE
feat(comments): notify teammates on @mention

### DIFF
--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -1765,6 +1765,29 @@ def get_users():
     return jsonify({"users": [user.to_dict(total_hours_override=total_hours_by_user.get(user.id)) for user in users]})
 
 
+@api_bp.route("/api/users/search")
+@login_required
+def search_users_for_mentions():
+    """Lightweight active-user list for @mention autocomplete.
+
+    Available to any authenticated user (unlike /api/users, which is admin
+    only) and returns just the fields the mention UI needs. An optional ``q``
+    query narrows the list by username or display name.
+    """
+    q = (request.args.get("q") or "").strip().lower()
+    query = User.query.filter_by(is_active=True)
+    if q:
+        like = f"%{q}%"
+        query = query.filter(
+            db.or_(
+                db.func.lower(User.username).like(like),
+                db.func.lower(User.full_name).like(like),
+            )
+        )
+    users = query.order_by(User.username).limit(500).all()
+    return jsonify({"users": [{"id": u.id, "username": u.username, "display_name": u.display_name} for u in users]})
+
+
 @api_bp.route("/api/stats")
 @login_required
 def get_stats():

--- a/app/routes/api_v1.py
+++ b/app/routes/api_v1.py
@@ -1289,6 +1289,10 @@ def create_comment():
     )
     db.session.add(cmt)
     db.session.commit()
+    # Notify any @mentioned teammates (best-effort; never blocks the response)
+    from app.services.mention_service import notify_mentioned_users
+
+    notify_mentioned_users(cmt, g.api_user)
     return jsonify({"message": "Comment created successfully", "comment": cmt.to_dict()}), 201
 
 

--- a/app/routes/comments.py
+++ b/app/routes/comments.py
@@ -80,6 +80,10 @@ def create_comment():
             # Log comment creation
             log_event("comment.created", user_id=current_user.id, comment_id=comment.id, target_type=target_type)
             track_event(current_user.id, "comment.created", {"comment_id": comment.id, "target_type": target_type})
+            # Notify any @mentioned teammates (best-effort; never blocks the comment)
+            from app.services.mention_service import notify_mentioned_users
+
+            notify_mentioned_users(comment, current_user)
             flash(_("Comment added successfully"), "success")
         else:
             flash(_("Error adding comment"), "error")

--- a/app/services/mention_service.py
+++ b/app/services/mention_service.py
@@ -1,0 +1,144 @@
+"""Detect @username mentions in comments and notify the mentioned users.
+
+A comment author can reference a teammate with ``@their_username``. When a
+comment is saved we parse those handles, resolve them to active users (never
+the author themselves), and deliver a notification through the same web-push
+channel the app already uses for reminders, plus a per-user Socket.IO event
+for any client that is listening in real time.
+
+Delivery degrades gracefully: if pywebpush / VAPID keys are not configured, no
+push is sent but mention resolution and the Socket.IO emit still work.
+"""
+
+import re
+
+from app import db
+
+# @handle: letters, digits, underscore, dot, hyphen. The negative lookbehind
+# keeps us from matching the "@" inside an email address (e.g. a@b.com) since
+# it would be preceded by a word character.
+_MENTION_RE = re.compile(r"(?<![\w.@-])@([A-Za-z0-9][A-Za-z0-9._-]*)")
+
+
+def extract_mention_usernames(content):
+    """Return the set of lowercased usernames referenced with @ in content."""
+    if not content:
+        return set()
+    handles = set()
+    for raw in _MENTION_RE.findall(content):
+        # Trim trailing punctuation that commonly follows a handle in prose.
+        handle = raw.rstrip(".-_")
+        if handle:
+            handles.add(handle.lower())
+    return handles
+
+
+def resolve_mentioned_users(content, exclude_user_id=None):
+    """Resolve @handles in content to active User rows (excluding the author)."""
+    handles = extract_mention_usernames(content)
+    if not handles:
+        return []
+
+    from app.models import User
+
+    query = User.query.filter(db.func.lower(User.username).in_(handles), User.is_active.is_(True))
+    if exclude_user_id is not None:
+        query = query.filter(User.id != exclude_user_id)
+    return query.all()
+
+
+def _mention_target(comment):
+    """Return (label, url) describing where the comment lives, for the note."""
+    from flask import url_for
+
+    if comment.task_id:
+        try:
+            url = url_for("tasks.view_task", task_id=comment.task_id)
+        except Exception:
+            url = None
+        return (comment.target_name, url)
+    if comment.project_id:
+        try:
+            url = url_for("projects.view_project", project_id=comment.project_id)
+        except Exception:
+            url = None
+        return (comment.target_name, url)
+    if comment.quote_id:
+        try:
+            url = url_for("quotes.view_quote", quote_id=comment.quote_id)
+        except Exception:
+            url = None
+        return (comment.target_name, url)
+    return (comment.target_name, None)
+
+
+def _build_note(comment, actor):
+    """Build the push/socket payload for a mention notification."""
+    actor_name = getattr(actor, "display_name", None) or getattr(actor, "username", None) or "Someone"
+    label, url = _mention_target(comment)
+    snippet = (comment.content or "").strip()
+    if len(snippet) > 140:
+        snippet = snippet[:137] + "…"
+    where = f" in {label}" if label and label != "Unknown" else ""
+    return {
+        "kind": "mention",
+        "title": f"{actor_name} mentioned you",
+        "message": f"{actor_name} mentioned you{where}: {snippet}",
+        "type": "info",
+        "action": url,
+        "comment_id": comment.id,
+        "target_type": comment.target_type,
+    }
+
+
+def notify_mentioned_users(comment, actor):
+    """Notify every user mentioned in the comment (excluding the actor).
+
+    Returns the list of notified user ids. Never raises: notification is a
+    best-effort side effect of saving a comment and must not break the request.
+    """
+    try:
+        actor_id = getattr(actor, "id", None)
+        users = resolve_mentioned_users(comment.content, exclude_user_id=actor_id)
+        if not users:
+            return []
+
+        note = _build_note(comment, actor)
+        notified = []
+        for user in users:
+            _deliver_web_push(user, note)
+            _emit_socket(user, note)
+            notified.append(user.id)
+        return notified
+    except Exception:
+        # Best-effort: log at debug via app logger if available, else swallow.
+        try:
+            from flask import current_app
+
+            current_app.logger.debug("mention notification failed", exc_info=True)
+        except Exception:
+            pass
+        return []
+
+
+def _deliver_web_push(user, note):
+    """Send the mention as a web-push to the user's subscriptions, if any."""
+    try:
+        from app.models import PushSubscription
+        from app.utils.scheduled_tasks import _deliver_push_to_subscriptions
+
+        subscriptions = PushSubscription.get_user_subscriptions(user.id)
+        if subscriptions:
+            _deliver_push_to_subscriptions(user, subscriptions, note)
+    except Exception:
+        pass
+
+
+def _emit_socket(user, note):
+    """Emit a real-time mention event to the user's Socket.IO room."""
+    try:
+        from app import socketio
+
+        socketio.emit("user_mentioned", note, room=f"user_{user.id}")
+    except Exception:
+        pass

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1580,6 +1580,30 @@
     <script src="{{ url_for('static', filename='floating-actions.js') }}?v={{ app_version }}"></script>
     <script src="{{ url_for('static', filename='floating-timer-bar.js') }}"></script>
     <script src="{{ url_for('static', filename='idle.js') }}"></script>
+    <!-- Real-time @mention notifications -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.5.4/socket.io.min.js" crossorigin="anonymous"></script>
+    <script>
+        (function(){
+            var uid = {{ current_user.id }};
+            if (!uid || typeof io === 'undefined') return;
+            try {
+                var socket = io();
+                socket.on('connect', function(){ socket.emit('join_user_room', { user_id: uid }); });
+                socket.on('user_mentioned', function(data){
+                    if (!data) return;
+                    var title = data.title || '{{ _('New mention') }}';
+                    var msg = data.message || '{{ _('You were mentioned in a comment') }}';
+                    if (window.toastManager && typeof window.toastManager.info === 'function') {
+                        window.toastManager.info(msg, title);
+                    } else if (typeof showToast === 'function') {
+                        try { showToast(msg, 'info'); } catch (e) {}
+                    }
+                });
+            } catch (e) {
+                console.error('Mention socket init failed', e);
+            }
+        })();
+    </script>
     {% if ai_enabled %}
     <script src="{{ url_for('static', filename='ai-helper.js') }}?v={{ app_version }}-ai1"></script>
     {% endif %}

--- a/app/templates/comments/_comment.html
+++ b/app/templates/comments/_comment.html
@@ -154,7 +154,7 @@
             {% endif %}
             <input type="hidden" name="parent_id" value="{{ comment.id }}">
             <div class="mb-3">
-                <textarea name="content" class="form-control" rows="3" placeholder="{{ _('Write your reply...') }}" required></textarea>
+                <textarea name="content" class="form-control" rows="3" data-mentions placeholder="{{ _('Write your reply...') }}" required></textarea>
             </div>
             <div class="d-flex gap-2">
                 <button type="submit" class="btn btn-primary btn-sm">

--- a/app/templates/comments/_comments_section.html
+++ b/app/templates/comments/_comments_section.html
@@ -26,10 +26,10 @@
                     {% endif %}
                     <div class="mb-3">
                         <label for="comment-content" class="form-label">{{ _('Your Comment') }}</label>
-                        <textarea name="content" id="comment-content" class="form-control" rows="4" 
+                        <textarea name="content" id="comment-content" class="form-control" rows="4" data-mentions
                                   placeholder="{{ _('Share your thoughts, updates, or questions...') }}" required></textarea>
                         <div class="form-text d-flex justify-content-between align-items-center">
-                            <span>{{ _('You can use line breaks to format your comment.') }}</span>
+                            <span>{{ _('Type @ to mention a teammate. You can use line breaks to format your comment.') }}</span>
                             <label class="btn btn-sm btn-outline-secondary mb-0">
                                 <i class="fas fa-image me-1"></i>{{ _('Add Image') }}
                                 <input type="file" id="commentImageInput" accept="image/*" class="d-none">

--- a/app/templates/quotes/view.html
+++ b/app/templates/quotes/view.html
@@ -288,7 +288,7 @@
                 <input type="hidden" name="quote_id" value="{{ quote.id }}">
                 <div>
                     <label for="comment-content" class="form-label">{{ _('Your Comment') }}</label>
-                    <textarea name="content" id="comment-content" rows="4" class="w-full form-input" placeholder="{{ _('Share your thoughts, updates, or questions...') }}" required></textarea>
+                    <textarea name="content" id="comment-content" rows="4" class="w-full form-input" data-mentions placeholder="{{ _('Share your thoughts, updates, or questions...') }}" required></textarea>
                 </div>
                 <div class="flex items-center">
                     <label class="flex items-center">
@@ -373,7 +373,7 @@
                                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                 <input type="hidden" name="quote_id" value="{{ quote.id }}">
                                 <input type="hidden" name="parent_id" value="{{ comment.id }}">
-                                <textarea name="content" rows="2" class="w-full form-input text-sm" placeholder="{{ _('Write a reply...') }}" required></textarea>
+                                <textarea name="content" rows="2" class="w-full form-input text-sm" data-mentions placeholder="{{ _('Write a reply...') }}" required></textarea>
                                 <div class="flex items-center mt-1">
                                     <label class="flex items-center">
                                         <input type="checkbox" name="is_internal" value="true" checked class="mr-2">

--- a/tests/test_mention_service.py
+++ b/tests/test_mention_service.py
@@ -1,0 +1,149 @@
+"""Tests for @mention detection and notification (app/services/mention_service.py)."""
+
+from app import db
+from app.models import Comment, User
+from app.services import mention_service
+
+# ---------------------------------------------------------------------------
+# extract_mention_usernames
+# ---------------------------------------------------------------------------
+
+
+def test_extract_single_mention():
+    assert mention_service.extract_mention_usernames("hey @alice") == {"alice"}
+
+
+def test_extract_multiple_mentions():
+    handles = mention_service.extract_mention_usernames("@alice and @bob, also @Carol")
+    assert handles == {"alice", "bob", "carol"}
+
+
+def test_extract_lowercases_handles():
+    assert mention_service.extract_mention_usernames("ping @AliceBob") == {"alicebob"}
+
+
+def test_extract_trims_trailing_punctuation():
+    # A handle at the end of a sentence should not keep the period.
+    assert mention_service.extract_mention_usernames("thanks @dave.") == {"dave"}
+
+
+def test_extract_ignores_email_addresses():
+    # The "@" in an email is preceded by a word char and must not match.
+    assert mention_service.extract_mention_usernames("mail me at bob@example.com") == set()
+
+
+def test_extract_handles_dotted_and_hyphenated_names():
+    handles = mention_service.extract_mention_usernames("@jane.doe and @mary-sue")
+    assert handles == {"jane.doe", "mary-sue"}
+
+
+def test_extract_empty_content():
+    assert mention_service.extract_mention_usernames("") == set()
+    assert mention_service.extract_mention_usernames(None) == set()
+
+
+# ---------------------------------------------------------------------------
+# resolve_mentioned_users
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_matches_active_user(app, user):
+    resolved = mention_service.resolve_mentioned_users(f"hi @{user.username}")
+    assert [u.id for u in resolved] == [user.id]
+
+
+def test_resolve_is_case_insensitive(app, user):
+    resolved = mention_service.resolve_mentioned_users(f"hi @{user.username.upper()}")
+    assert [u.id for u in resolved] == [user.id]
+
+
+def test_resolve_excludes_author(app, user):
+    resolved = mention_service.resolve_mentioned_users(f"@{user.username}", exclude_user_id=user.id)
+    assert resolved == []
+
+
+def test_resolve_skips_inactive_users(app):
+    ghost = User(username="ghost_mention", role="user", email="ghost@example.com")
+    ghost.is_active = False
+    db.session.add(ghost)
+    db.session.commit()
+    resolved = mention_service.resolve_mentioned_users("@ghost_mention")
+    assert resolved == []
+
+
+def test_resolve_no_handles_returns_empty(app, user):
+    assert mention_service.resolve_mentioned_users("no mentions here") == []
+
+
+# ---------------------------------------------------------------------------
+# notify_mentioned_users (best-effort, never raises)
+# ---------------------------------------------------------------------------
+
+
+def test_notify_returns_mentioned_ids(app, user, project):
+    actor = User(username="mention_actor", role="user", email="actor@example.com")
+    actor.is_active = True
+    db.session.add(actor)
+    db.session.commit()
+
+    comment = Comment(content=f"cc @{user.username}", user_id=actor.id, project_id=project.id)
+    db.session.add(comment)
+    db.session.commit()
+
+    notified = mention_service.notify_mentioned_users(comment, actor)
+    assert notified == [user.id]
+
+
+def test_notify_excludes_the_actor(app, user, project):
+    comment = Comment(
+        content=f"note to self @{user.username}",
+        user_id=user.id,
+        project_id=project.id,
+    )
+    db.session.add(comment)
+    db.session.commit()
+
+    notified = mention_service.notify_mentioned_users(comment, user)
+    assert notified == []
+
+
+def test_notify_never_raises_on_bad_comment(app, user):
+    # Passing a bare object with no content must not blow up the caller.
+    class _Broken:
+        content = None
+        task_id = None
+        project_id = None
+        quote_id = None
+        id = None
+        target_type = None
+
+    assert mention_service.notify_mentioned_users(_Broken(), user) == []
+
+
+# ---------------------------------------------------------------------------
+# /api/users/search endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_search_users_endpoint_requires_login(client):
+    resp = client.get("/api/users/search")
+    # Unauthenticated request is redirected to login or rejected.
+    assert resp.status_code in (301, 302, 401, 403)
+
+
+def test_search_users_endpoint_filters_by_query(authenticated_client, user):
+    resp = authenticated_client.get(f"/api/users/search?q={user.username}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "users" in data
+    usernames = [u["username"] for u in data["users"]]
+    assert user.username in usernames
+
+
+def test_search_users_endpoint_returns_display_name(authenticated_client, user):
+    resp = authenticated_client.get("/api/users/search")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data["users"], list)
+    if data["users"]:
+        assert {"id", "username", "display_name"} <= set(data["users"][0].keys())


### PR DESCRIPTION
## Summary

Notifies teammates when they're **@mentioned in a comment** — type `@username` in any task/project/quote comment and the mentioned users get a real-time toast (via the existing Socket.IO per-user room) plus a web-push notification if they have push enabled.

Comment mentions are how kanban/PM tools pull the right person into a conversation without a separate email or DM. This wires that up on top of the comment system already in place.

## What changed

- **New service** (`app/services/mention_service.py`): `extract_mention_usernames` (email-safe `@handle` parser), `resolve_mentioned_users` (active users, case-insensitive, excludes the comment author), and `notify_mentioned_users` — best-effort delivery that **never raises** into the comment path (web-push + `user_{id}` Socket.IO emit).
- **New endpoint** (`app/routes/api.py`): `GET /api/users/search` — login-required autocomplete source returning active users (`id` / `username` / `display_name`).
- **Wiring**: `create_comment` in both `app/routes/comments.py` and `app/routes/api_v1.py` calls `notify_mentioned_users` after the comment commits.
- **Frontend**: activates the existing dormant `mentions.js` autocomplete by adding `data-mentions` to the comment/reply textareas (`comments/_comment.html`, `comments/_comments_section.html`, `quotes/view.html`), and adds a small authenticated Socket.IO listener in `base.html` that toasts on `user_mentioned`.

## Compatibility

- Reuses the existing `socketio` instance, the pre-existing secure `join_user_room` handler (validates `current_user.id == user_id`), and the existing CSP allowances for `cdnjs.cloudflare.com` and `ws:/wss:` — no new infrastructure or CSP changes.
- Degrades gracefully: if `pywebpush`/VAPID isn't configured, push is skipped; if the socket isn't connected, the mention is simply not toasted. Notification failures never block comment creation.
- No migration.

## Test plan

- `tests/test_mention_service.py` — 18 tests: handle extraction (single/multiple, lowercasing, trailing-punctuation trim, email-address exclusion, dotted/hyphenated names, empty), resolution (active match, case-insensitive, author-exclusion, inactive-skip), best-effort notify (returns ids, excludes actor, never raises on a bad comment), and the `/api/users/search` endpoint (login required, query filter, display_name).
- `pytest tests/test_mention_service.py` → 18 passed.
- `black --check -l 120` clean.
