### PR TITLE
fix(migrations): merge parallel kanban feature heads into one

### DIFF
--- a/migrations/versions/171_merge_kanban_feature_heads.py
+++ b/migrations/versions/171_merge_kanban_feature_heads.py
@@ -1,0 +1,29 @@
+"""Merge the three parallel kanban feature migration heads into one.
+
+The per-column WIP limits (168), task checklists (169), and board templates
+(170) migrations were each authored off 166_add_slack_user_id as an independent
+branch, so with all three merged the revision graph has three heads and
+``flask db upgrade`` fails with "Multiple head revisions are present". This
+no-op merge migration rejoins them into a single head; each feature migration is
+independent (adds its own table/column), so no ordering constraint is imposed.
+
+Revision ID: 171_merge_kanban_feature_heads
+Revises: 168_add_kanban_wip_limit, 169_add_task_checklist_items, 170_add_kanban_board_templates
+"""
+
+revision = "171_merge_kanban_feature_heads"
+down_revision = (
+    "168_add_kanban_wip_limit",
+    "169_add_task_checklist_items",
+    "170_add_kanban_board_templates",
+)
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
## Problem

v5.9.3 has **three migration heads**. The three kanban feature migrations added in this release —

- `168_add_kanban_wip_limit`
- `169_add_task_checklist_items`
- `170_add_kanban_board_templates`

— were each authored as an independent branch off `166_add_slack_user_id` (so any one could land first). With all three now merged, the revision graph has three leaves:

```
$ flask db heads
168_add_kanban_wip_limit (head)
169_add_task_checklist_items (head)
170_add_kanban_board_templates (head)
```

As a result, `flask db upgrade` on a fresh database fails:

```
ERROR [alembic.util.messaging] Multiple head revisions are present for
given argument 'head'; please specify a specific target revision...
```

The v5.9.3 release build passed because the desktop/mobile build jobs don't run migrations, so the multi-head state isn't exercised there — but it breaks any actual deploy/upgrade.

## Fix

Add a single no-op merge migration (`171_merge_kanban_feature_heads`) whose `down_revision` is the tuple of the three heads, rejoining them into one. Each feature migration is independent (each adds its own table/column with `IF NOT EXISTS`-style guards), so no ordering constraint is imposed.

## Verification

On a checkout of this branch:

```
$ flask db heads
171_merge_kanban_feature_heads (head)

$ flask db upgrade      # against an empty database
... (completes, exit 0)
```

No schema change — this only reconciles the revision graph.