### PR TITLE
fix(contacts): stop TypeError when logging a contact communication

### DIFF
--- a/app/routes/contacts.py
+++ b/app/routes/contacts.py
@@ -10,7 +10,7 @@ from app import db
 from app.models import Client, Contact, ContactCommunication
 from app.utils.db import safe_commit
 from app.utils.module_helpers import module_enabled
-from app.utils.timezone import parse_local_datetime
+from app.utils.timezone import parse_local_datetime_from_string
 
 contacts_bp = Blueprint("contacts", __name__)
 
@@ -160,10 +160,10 @@ def create_communication(contact_id):
     if request.method == "POST":
         try:
             comm_date_str = request.form.get("communication_date", "")
-            comm_date = parse_local_datetime(comm_date_str) if comm_date_str else datetime.utcnow()
+            comm_date = parse_local_datetime_from_string(comm_date_str) or datetime.utcnow()
 
             follow_up_str = request.form.get("follow_up_date", "")
-            follow_up_date = parse_local_datetime(follow_up_str) if follow_up_str else None
+            follow_up_date = parse_local_datetime_from_string(follow_up_str) if follow_up_str else None
 
             communication = ContactCommunication(
                 contact_id=contact_id,

--- a/tests/test_contacts_communication_date.py
+++ b/tests/test_contacts_communication_date.py
@@ -1,0 +1,38 @@
+"""Regression test for the contact-communication date parsing crash.
+
+The "New Communication" form submits ``communication_date`` / ``follow_up_date``
+as single ``<input type="datetime-local">`` values (``YYYY-MM-DDTHH:MM``). The
+route previously called ``parse_local_datetime(value)`` with a single argument,
+but that helper's signature is ``parse_local_datetime(date_str, time_str)`` — so
+every real submission raised ``TypeError: parse_local_datetime() missing 1
+required positional argument: 'time_str'`` before a record could be created.
+
+The fix routes both fields through ``parse_local_datetime_from_string`` (which
+parses the combined datetime-local string and is None-safe).
+"""
+
+import pytest
+
+from app.utils.timezone import parse_local_datetime, parse_local_datetime_from_string
+
+
+def test_single_arg_parse_local_datetime_still_requires_two_args(app):
+    """Guards the root cause: the old single-arg call is a TypeError."""
+    with app.app_context():
+        with pytest.raises(TypeError):
+            parse_local_datetime("2026-07-19T14:30")
+
+
+def test_from_string_parses_datetime_local_value(app):
+    """The datetime-local form value parses to a concrete datetime."""
+    with app.app_context():
+        parsed = parse_local_datetime_from_string("2026-07-19T14:30")
+        assert parsed is not None
+        assert parsed.year == 2026 and parsed.month == 7 and parsed.day == 19
+
+
+@pytest.mark.parametrize("value", ["", "not-a-date", "2026-07-19"])  # no 'T' -> None
+def test_from_string_is_none_safe(app, value):
+    """Empty/invalid input returns None so the caller's fallback applies."""
+    with app.app_context():
+        assert parse_local_datetime_from_string(value) is None


### PR DESCRIPTION
### Problem

The **New Communication** form (`/clients/<id>/contacts/<id>/communications/new`) submits `communication_date` and `follow_up_date` as single `<input type="datetime-local">` values (`YYYY-MM-DDTHH:MM`).

The route parsed them with a single-argument call:

```python
comm_date = parse_local_datetime(comm_date_str) if comm_date_str else datetime.utcnow()
```

but `parse_local_datetime`'s signature is `parse_local_datetime(date_str, time_str)`. So every real submission raised:

```
TypeError: parse_local_datetime() missing 1 required positional argument: 'time_str'
```

before the `ContactCommunication` record could be created — logging a contact communication was unusable.

### Fix

Route both fields through the existing `parse_local_datetime_from_string()` helper, which parses the combined `datetime-local` string and is `None`-safe (returns `None` on empty/invalid input, so the existing `utcnow()` fallback for `communication_date` is preserved).

```python
comm_date = parse_local_datetime_from_string(comm_date_str) or datetime.utcnow()
...
follow_up_date = parse_local_datetime_from_string(follow_up_str) if follow_up_str else None
```

### Tests

Adds `tests/test_contacts_communication_date.py` (5 tests):
- guards the root cause — the old single-arg call is a `TypeError`
- the `datetime-local` value parses to a concrete datetime
- empty / invalid / no-`T` input returns `None` so the caller's fallback applies

All pass; `flake8 --select=F`, `black --line-length 120`, and `isort` clean.