### PR TITLE
chore(format): satisfy black + isort on client_portal_session.py

### DIFF
--- a/app/utils/client_portal_session.py
+++ b/app/utils/client_portal_session.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from flask import request, session, url_for
 from flask.helpers import redirect
 
-
 _NATIVE_CLIENT_ALLOWED_ENDPOINTS = frozenset(
     {
         "auth.login",


### PR DESCRIPTION
### Problem

The **Code Quality Checks** job runs `black --check app/` and `isort --check-only app/` across the entire tree. `app/utils/client_portal_session.py` has an extra blank line after its imports that both tools flag:

```
would reformat app/utils/client_portal_session.py            # black
ERROR: .../client_portal_session.py Imports are incorrectly sorted   # isort
```

Because the check scans the whole tree, the job fails on **every** pull request regardless of the change under review — the baseline on `main` is already red.

### Fix

Remove the single stray blank line after the imports so the file is black- and isort-clean. No behavioural change — formatting only.

Verified locally against `pyproject.toml` (line-length 120):

```
black --check app/utils/client_portal_session.py   -> would be left unchanged
isort --check-only app/utils/client_portal_session.py -> clean
```