### PR TITLE
fix(api): restore client update, expose Peppol send, map invoice buyer_reference/issue_date + totals recompute

### DIFF
--- a/app/routes/api_v1_clients.py
+++ b/app/routes/api_v1_clients.py
@@ -222,3 +222,39 @@ def post_client_invoice_unbilled(client_id):
         ),
         200,
     )
+
+
+@api_v1_clients_bp.route("/clients/<int:client_id>", methods=["PUT", "PATCH"])
+@require_api_token("write:clients")
+def update_client_api(client_id):
+    """Update a client — restores the pre-5.9 token-API update and adds custom_fields.
+
+    the v5.9+ per-resource API refactor dropped client update;
+    needed for Peppol recipient ids (custom_fields.peppol_endpoint_id/scheme_id).
+    """
+    blocked = _require_module_enabled_for_api("clients")
+    if blocked:
+        return blocked
+    from decimal import Decimal
+
+    from app.services import ClientService
+
+    data = request.get_json() or {}
+    allowed = {}
+    for field in ("name", "email", "company", "phone", "address"):
+        if field in data:
+            allowed[field] = data[field]
+    if data.get("default_hourly_rate") is not None:
+        allowed["default_hourly_rate"] = Decimal(str(data["default_hourly_rate"]))
+    if data.get("custom_fields") is not None:
+        allowed["custom_fields"] = data["custom_fields"]
+    if not allowed:
+        return validation_error_response(
+            errors={"body": ["No updatable fields provided"]},
+            message="No updatable fields provided",
+        )
+    result = ClientService().update_client(client_id, g.api_user.id, **allowed)
+    if not result.get("success"):
+        status = 404 if result.get("error") == "not_found" else 400
+        return error_response(result.get("message", "Could not update client"), status_code=status)
+    return jsonify({"message": "Client updated successfully", "client": result["client"].to_dict()})

--- a/app/routes/api_v1_invoices.py
+++ b/app/routes/api_v1_invoices.py
@@ -122,9 +122,14 @@ def update_invoice(invoice_id):
 
     data = request.get_json() or {}
     update_kwargs = {}
-    for field in ("client_name", "client_email", "client_address", "notes", "terms", "status", "currency_code"):
+    # API update dropped; also recompute totals after a tax_rate change (see below).
+    for field in ("client_name", "client_email", "client_address", "notes", "terms", "status", "currency_code", "buyer_reference"):
         if field in data:
             update_kwargs[field] = data[field]
+    if "issue_date" in data:
+        parsed = _parse_date(data["issue_date"])
+        if parsed:
+            update_kwargs["issue_date"] = parsed
     if "due_date" in data:
         parsed = _parse_date(data["due_date"])
         if parsed:
@@ -145,6 +150,21 @@ def update_invoice(invoice_id):
     result = invoice_service.update_invoice(invoice_id=invoice_id, user_id=g.api_user.id, **update_kwargs)
     if not result.get("success"):
         return error_response(result.get("message", "Could not update invoice"), status_code=400)
+    # InvoiceService.update_invoice — set them directly (same pattern as amount_paid below).
+    direct_dirty = False
+    if "buyer_reference" in data:
+        result["invoice"].buyer_reference = data["buyer_reference"]
+        direct_dirty = True
+    if "issue_date" in data:
+        parsed_issue = _parse_date(data["issue_date"])
+        if parsed_issue:
+            result["invoice"].issue_date = parsed_issue
+            direct_dirty = True
+    if "tax_rate" in update_kwargs:
+        result["invoice"].calculate_totals()
+        direct_dirty = True
+    if direct_dirty:
+        db.session.commit()
     if "amount_paid" in data:
         result["invoice"].update_payment_status()
         db.session.commit()
@@ -397,3 +417,30 @@ def reject_invoice_approval(approval_id):
             "invoice_approval": _approval_to_api_dict(result["approval"]),
         }
     )
+
+
+@api_v1_invoices_bp.route("/invoices/<int:invoice_id>/send-peppol", methods=["POST"])
+@require_api_token("write:invoices")
+def send_invoice_peppol_api(invoice_id):
+    """Token-auth Peppol send — API twin of the @login_required web route.
+
+    upstream exposes Peppol send only as a session web route;
+    agents need a token-scoped path. Mirrors send_invoice_peppol_route.
+    """
+    from app.models import Invoice
+    from app.services import PeppolService
+
+    invoice = Invoice.query.get(invoice_id)
+    if not invoice:
+        return error_response("Invoice not found", status_code=404)
+    try:
+        success, tx, message = PeppolService().send_invoice(
+            invoice=invoice, triggered_by_user_id=g.api_user.id
+        )
+    except Exception as e:
+        current_app.logger.error(f"API Peppol send failed: {type(e).__name__}: {e}")
+        return error_response(f"Failed to send via Peppol: {e}", status_code=502)
+    payload = {"success": success, "message": message, "peppol_tx_id": tx.id if tx else None}
+    if success:
+        return jsonify(payload)
+    return jsonify(payload), 400


### PR DESCRIPTION
## What

Three API-parity fixes on `/api/v1`, found while integrating TimeTracker with a headless (API-token) billing workflow:

1. **`PUT/PATCH /api/v1/clients/<id>` — restored.** The v5.9 per-resource API refactor dropped the client-update endpoint entirely (only GET list/one + POST create survived in `api_v1_clients.py`). Restored with `custom_fields` passthrough, which is also how Peppol recipient identifiers (`peppol_endpoint_id` / `peppol_scheme_id`) are stored.
2. **`POST /api/v1/invoices/<id>/send-peppol` — new.** Peppol send currently exists only as the session-only web route (`@login_required` `send_invoice_peppol_route`). This adds an API-token twin (scope `write:invoices`) using the exact same `PeppolService().send_invoice(...)` call chain, so integrations can send without a browser session.
3. **`PUT /api/v1/invoices/<id>` — field gaps.** `buyer_reference` (Peppol BT-10 — the model column even carries that comment) and `issue_date` were silently dropped by the update handler, and a `tax_rate` change never recomputed totals (`tax_amount`/`total_amount` stayed stale). Mapped both fields (same direct-set pattern as `amount_paid`) and `calculate_totals()` on rate change.

## Verification

Running in production on a v5.10.1 source build: full end-to-end Peppol send over the token route (bridge → Peppyrus, live transmission accepted, `peppol_tx_id` returned), client custom_fields round-trip, and invoice update with BT-10 + correct recomputed totals (21% VAT). Routes return 401 unauthenticated / 403 without scope, consistent with siblings.

Related: #700-era Peppyrus auth-header fix (X-Api-Key) which is now upstream — same integration effort. A companion PR fixes the Peppyrus documentType format in the bridge provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)