### PR TITLE
fix(peppol-bridge): scheme-prefix documentType/processType for Peppyrus /message

### DIFF
--- a/peppol_bridge/providers/peppyrus.py
+++ b/peppol_bridge/providers/peppyrus.py
@@ -53,6 +53,14 @@ class PeppyrusProvider(ProviderBase):
         process_id: str,
     ) -> ProviderSendResult:
         url = f"{self.base_url}/message"
+        # Peppyrus /v1 requires scheme-prefixed identifiers (see its OpenAPI MessageBody
+        # examples): documentType: busdox-docid-qns::<docid>, processType:
+        # cenbii-procid-ubl::<procid>. Bare ids are rejected with HTTP 422
+        # "Incorrect documentType".
+        if document_type_id and not document_type_id.startswith("busdox-docid-qns::"):
+            document_type_id = f"busdox-docid-qns::{document_type_id}"
+        if process_id and not process_id.startswith("cenbii-procid-ubl::"):
+            process_id = f"cenbii-procid-ubl::{process_id}"
         payload = {
             "sender": f"{sender_scheme_id}:{sender_endpoint_id}" if sender_scheme_id else sender_endpoint_id,
             "recipient": f"{recipient_scheme_id}:{recipient_endpoint_id}" if recipient_scheme_id else recipient_endpoint_id,


### PR DESCRIPTION
## What

`PeppyrusProvider.send_ubl` posts `documentType` / `processType` as bare identifiers (e.g. `urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##...::2.1`). The Peppyrus `/v1/message` API requires the **scheme-prefixed** forms per its OpenAPI `MessageBody` examples:

- `documentType`: `busdox-docid-qns::<docid>`
- `processType`: `cenbii-procid-ubl::<procid>`

Bare ids are rejected with **HTTP 422 "Incorrect documentType"**, so every send through the bundled bridge fails against the current Peppyrus API. The fix prefixes both when missing (idempotent — already-prefixed values pass through).

## Verification

Live against production Peppyrus: before the fix every `/message` call returned 422; after it, an end-to-end BIS Billing 3.0 invoice send succeeded (accepted by Peppyrus, transaction id returned, delivery confirmed). Same integration effort as the earlier X-Api-Key auth fix that is now upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)