### PR TITLE
feat(peppol): verify access-point delivery status after send

### DIFF
--- a/app/routes/api_v1_invoices.py
+++ b/app/routes/api_v1_invoices.py
@@ -397,3 +397,38 @@ def reject_invoice_approval(approval_id):
             "invoice_approval": _approval_to_api_dict(result["approval"]),
         }
     )
+
+
+@api_v1_invoices_bp.route("/invoices/<int:invoice_id>/peppol-status", methods=["GET"])
+@require_api_token("read:invoices")
+def invoice_peppol_status_api(invoice_id):
+    """Latest Peppol transmission for an invoice, refreshed against the access point.
+
+    The AP validates async — a tx recorded 'sent' can still fail later; this
+    re-checks the AP folder and corrects the tx record when it failed.
+    """
+    from app.models import Invoice, InvoicePeppolTransmission
+    from app.services import PeppolService
+
+    invoice = Invoice.query.get(invoice_id)
+    if not invoice:
+        return error_response("Invoice not found", status_code=404)
+    tx = (
+        InvoicePeppolTransmission.query.filter_by(invoice_id=invoice_id)
+        .order_by(InvoicePeppolTransmission.id.desc())
+        .first()
+    )
+    if tx is None:
+        return jsonify({"invoice_id": invoice_id, "transmission": None})
+    refreshed = PeppolService().refresh_transmission_status(tx)
+    return jsonify(
+        {
+            "invoice_id": invoice_id,
+            "peppol_tx_id": tx.id,
+            "status": tx.status,
+            "message_id": tx.message_id,
+            "error_message": tx.error_message,
+            "ap_folder": refreshed.get("folder"),
+            "ap_fatal_rules": refreshed.get("fatal_rules"),
+        }
+    )

--- a/app/services/peppol_service.py
+++ b/app/services/peppol_service.py
@@ -1,5 +1,6 @@
 import os
-from typing import Optional, Tuple
+import time
+from typing import List, Optional, Tuple
 
 from flask import current_app
 
@@ -79,6 +80,78 @@ class PeppolService:
             phone=(getattr(client, "phone", None) or "").strip() or None,
         )
         return party, endpoint_id, scheme_id
+
+    @staticmethod
+    def _poll_ap_status(
+        ap_url: str, ap_token: Optional[str], message_id: str,
+        attempts: int = 4, delay_s: float = 4.0,
+    ) -> Tuple[Optional[str], List[dict]]:
+        """Poll the access-point adapter for the AP-side folder of an outbound message.
+
+        Returns (folder lowercased or None, fatal_rules).
+        Stops early on a terminal folder (sent/failed); never raises.
+        """
+        import requests
+
+        base = (ap_url or "").strip().rstrip("/")
+        if base.endswith("/send"):
+            base = base[: -len("/send")]
+        if not base:
+            return None, []
+        url = f"{base}/message/{message_id}/status"
+        # The settings row can hold an empty access-point token (non-None), which wins
+        # over the env var in the caller's resolution; the send transport falls back to
+        # PEPPOL_ACCESS_POINT_TOKEN internally — mirror that here or status polls 401.
+        if not ap_token:
+            ap_token = (os.getenv("PEPPOL_ACCESS_POINT_TOKEN") or "").strip() or None
+        headers = {"Authorization": f"Bearer {ap_token}"} if ap_token else {}
+        folder: Optional[str] = None
+        rules: List[dict] = []
+        for i in range(max(1, attempts)):
+            if i:
+                time.sleep(delay_s)
+            try:
+                resp = requests.get(url, headers=headers, timeout=15)
+                if resp.status_code >= 400:
+                    continue
+                data = resp.json() or {}
+                folder = (data.get("folder") or "").strip().lower() or None
+                rules = data.get("fatal_rules") or []
+                if folder in {"sent", "failed"}:
+                    break
+            except Exception:
+                continue
+        return folder, rules
+
+    def refresh_transmission_status(self, tx) -> dict:
+        """One AP status check for an existing transmission; corrects tx.status when the
+        AP reports failure after we recorded 'sent'."""
+        if tx is None or not getattr(tx, "message_id", None):
+            return {"folder": None, "fatal_rules": []}
+        settings = Settings.get_settings()
+        transport_mode = (
+            (getattr(settings, "peppol_transport_mode", None) or os.getenv("PEPPOL_TRANSPORT_MODE") or "generic")
+            .strip().lower()
+        )
+        if transport_mode == "native":
+            return {"folder": None, "fatal_rules": []}
+        ap_url = (
+            getattr(settings, "peppol_access_point_url", "") or os.getenv("PEPPOL_ACCESS_POINT_URL") or ""
+        ).strip()
+        ap_token_raw = getattr(settings, "peppol_access_point_token", None)
+        ap_token = (
+            (settings.get_secret("peppol_access_point_token") or "").strip()
+            if ap_token_raw is not None
+            else (os.getenv("PEPPOL_ACCESS_POINT_TOKEN") or "").strip()
+        )
+        folder, rules = self._poll_ap_status(ap_url, ap_token or None, tx.message_id, attempts=1)
+        if folder == "failed" and tx.status != "failed":
+            reasons = "; ".join(
+                f"[{r.get('id')}] {r.get('message')}" for r in (rules or [])[:6]
+            ) or "access point reported delivery failure"
+            tx.mark_failed(f"Access point validation/delivery failed: {reasons}")
+            safe_commit("peppol_refresh_mark_failed", {"tx_id": tx.id})
+        return {"folder": folder, "fatal_rules": rules}
 
     def send_invoice(
         self, invoice, triggered_by_user_id: Optional[int] = None
@@ -177,6 +250,26 @@ class PeppolService:
             tx.mark_sent(message_id=message_id, response_payload=resp)
             if not safe_commit("peppol_mark_sent", {"invoice_id": invoice.id, "tx_id": tx.id}):
                 return True, tx, "Sent via Peppol, but failed to persist send status"
+
+            # The AP accepts synchronously but validates/transmits async — poll briefly
+            # so a validation failure doesn't masquerade as a successful send.
+            verify = (os.getenv("PEPPOL_VERIFY_AFTER_SEND", "true").strip().lower()
+                      in {"1", "true", "yes", "on"})
+            if verify and message_id and transport_mode != "native":
+                folder, fatal_rules = self._poll_ap_status(ap_url, ap_token or None, message_id)
+                if folder == "failed":
+                    reasons = "; ".join(
+                        f"[{r.get('id')}] {r.get('message')}" for r in (fatal_rules or [])[:6]
+                    ) or "access point reported delivery failure"
+                    tx.mark_failed(f"Access point validation/delivery failed: {reasons}")
+                    safe_commit("peppol_mark_failed", {"invoice_id": invoice.id, "tx_id": tx.id})
+                    return False, tx, f"Peppol send FAILED at access point: {reasons}"
+                if folder == "sent":
+                    return True, tx, "Invoice sent via Peppol (access point confirmed transmission)"
+                return True, tx, (
+                    "Invoice accepted by access point; async validation/delivery still pending — "
+                    "verify with the peppol-status endpoint before assuming delivery"
+                )
 
             return True, tx, "Invoice sent via Peppol"
         except PeppolTransportError as e:

--- a/peppol_bridge/app.py
+++ b/peppol_bridge/app.py
@@ -154,12 +154,29 @@ def create_app() -> Flask:
         except Exception as e:
             return _json_error(f"Send failed: {e}", 500)
 
+    @app.get("/message/<message_id>/status")
+    def message_status(message_id: str) -> Response:
+        # AP-side delivery status passthrough — a sync-accepted message can still fail
+        # async validation at the provider; callers verify delivery via this route.
+        if cfg.bridge_auth_token:
+            token = _require_bearer(request.headers.get("Authorization", ""))
+            if not token or token != cfg.bridge_auth_token:
+                return _json_error("Unauthorized", 401)
+        try:
+            provider = _build_provider(cfg)
+            data = provider.get_status(message_id)
+            return jsonify({"ok": True, "provider": provider.name, **data})
+        except ProviderError as e:
+            return _json_error(str(e), 502)
+        except Exception as e:
+            return _json_error(f"Status lookup failed: {e}", 500)
+
     @app.get("/")
     def index() -> Response:
         return jsonify(
             {
                 "service": "peppol-bridge",
-                "endpoints": ["/health", "/test", "/send"],
+                "endpoints": ["/health", "/test", "/send", "/message/<id>/status"],
             }
         )
 

--- a/peppol_bridge/providers/base.py
+++ b/peppol_bridge/providers/base.py
@@ -34,3 +34,11 @@ class ProviderBase:
     ) -> ProviderSendResult:
         raise NotImplementedError
 
+    def get_status(self, message_id: str) -> Dict[str, Any]:
+        """Return AP-side delivery status for a previously sent message.
+
+        Expected keys: folder (lowercase, e.g. outbox/sent/failed, None if unknown)
+        and fatal_rules (list of {id, message}) when the AP reports a failure.
+        """
+        raise ProviderError(f"Status lookup not supported by provider '{self.name}'")
+

--- a/peppol_bridge/providers/peppyrus.py
+++ b/peppol_bridge/providers/peppyrus.py
@@ -77,3 +77,36 @@ class PeppyrusProvider(ProviderBase):
             message_id = data.get("id") or data.get("message_id") or data.get("messageId")
         return ProviderSendResult(message_id=message_id, raw=data if isinstance(data, dict) else {"data": data})
 
+    def get_status(self, message_id: str) -> Dict[str, Any]:
+        # Peppyrus accepts POST /message synchronously but validates/transmits async;
+        # the message folder (Outbox -> Sent | Failed) is the real outcome. On Failed,
+        # /message/{id}/report carries the validation rule failures.
+        url = f"{self.base_url}/message/{message_id}"
+        try:
+            resp = requests.get(url, headers=self._headers(), timeout=self.timeout_s)
+        except Exception as e:
+            raise ProviderError(f"Failed to call Peppyrus /message/{{id}}: {e}") from e
+        if resp.status_code >= 400:
+            raise ProviderError(f"Peppyrus returned HTTP {resp.status_code}: {resp.text}")
+        try:
+            data = resp.json()
+        except Exception:
+            raise ProviderError(f"Peppyrus returned non-JSON status: {resp.text[:200]}")
+        if isinstance(data, dict):
+            data.pop("fileContent", None)
+        folder = (data.get("folder") or "").strip().lower() if isinstance(data, dict) else ""
+        out: Dict[str, Any] = {"folder": folder or None, "raw": data}
+        if folder == "failed":
+            try:
+                rep = requests.get(f"{url}/report", headers=self._headers(), timeout=self.timeout_s)
+                if rep.status_code < 400:
+                    rules = (rep.json() or {}).get("validationRules") or []
+                    out["fatal_rules"] = [
+                        {"id": r.get("id") or "XSD", "message": (r.get("message") or "")[:300]}
+                        for r in rules
+                        if (r.get("type") or "").upper() == "FATAL"
+                    ]
+            except Exception:
+                pass
+        return out
+


### PR DESCRIPTION
## Problem

Access points can accept a posted document synchronously and validate/transmit it **asynchronously**. Observed live with Peppyrus: `POST /message` → HTTP 200 + message id, async validation FATALs (see #717), message parked in the provider's `Failed` folder. `PeppolService.send_invoice` marks the transmission `sent` on the sync 200 and never re-checks — a completely failed delivery is indistinguishable from a successful one, for the user and in the DB.

## Change

- **peppol_bridge**: new `GET /message/<id>/status` passthrough (same bearer auth as `/send`). `ProviderBase.get_status()` with a Peppyrus implementation: returns the message folder (`outbox`/`sent`/`failed`) and, on failure, the FATAL validation rules from `/message/{id}/report`.
- **PeppolService.send_invoice**: brief post-send poll (env `PEPPOL_VERIFY_AFTER_SEND`, default on, generic transport only). If the AP reports `failed`, the tx is marked failed with the rule list and the call returns failure; if validation is still running, the success message says explicitly that delivery is pending.
- **New `GET /api/v1/invoices/<id>/peppol-status`** (`read:invoices`): returns the invoice's latest transmission refreshed against the AP, and corrects a stale `sent` record when the AP reports failure.
- Token resolution falls back to `PEPPOL_ACCESS_POINT_TOKEN` when the settings row holds an empty (non-None) token — matching what the send transport already does.

## Verification

Live against Peppyrus: a send that failed async validation is now recorded `failed` with the exact rule ids in `error_message`; a valid send reports "accepted; validation pending" and reaches folder `Sent` ~40 s later, confirmed via the new status endpoint. Independent of #717 but designed to catch exactly the failure mode it fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)