### PR TITLE
feat(peppol): embed the invoice PDF in the UBL as an attachment (BG-24/BT-125)

### DIFF
--- a/app/integrations/peppol.py
+++ b/app/integrations/peppol.py
@@ -14,13 +14,14 @@ Important:
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import os
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from datetime import date
 from decimal import Decimal
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Sequence, Tuple
 
 import requests
 
@@ -68,6 +69,25 @@ class PeppolParty:
     country_code: Optional[str] = None
     email: Optional[str] = None
     phone: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class PeppolAttachment:
+    """A supporting document to embed in the invoice (BG-24 / BT-125).
+
+    Typically the human-readable PDF of the invoice, so the recipient gets both the
+    structured data and something a person can read.
+
+    - ``document_id`` is BT-122, required by BR-52.
+    - ``filename`` must be unique case-insensitively across attachments (DE-R-022).
+    - ``mime_code`` must be on the EN 16931 mime code list (e.g. ``application/pdf``).
+    """
+
+    document_id: str
+    filename: str
+    mime_code: str
+    content: bytes
+    description: Optional[str] = None
 
 
 def _money(v: Any) -> str:
@@ -151,7 +171,12 @@ def _party(parent: ET.Element, kind: str, party: PeppolParty) -> None:
         _text(contact, cbc + "ElectronicMail", party.email)
 
 
-def build_peppol_ubl_invoice_xml(invoice: Any, supplier: PeppolParty, customer: PeppolParty) -> Tuple[str, str]:
+def build_peppol_ubl_invoice_xml(
+    invoice: Any,
+    supplier: PeppolParty,
+    customer: PeppolParty,
+    attachments: Optional[Sequence[PeppolAttachment]] = None,
+) -> Tuple[str, str]:
     """
     Build UBL 2.1 Invoice XML shaped for Peppol BIS Billing 3.0.
 
@@ -207,6 +232,27 @@ def build_peppol_ubl_invoice_xml(invoice: Any, supplier: PeppolParty, customer: 
         _text(inv_el, cbc + "BuyerReference", _buyer_ref)
 
     # Parties
+    # AdditionalDocumentReference (BG-24): supporting documents embedded in the invoice,
+    # e.g. the human-readable PDF of this invoice. The UBL 2.1 XSD sequence puts this after
+    # the document references and BEFORE Signature/AccountingSupplierParty; emitting it any
+    # later is XSD-invalid, and the access point only reports that asynchronously.
+    # Deliberately no cbc:DocumentTypeCode: code 130 marks an invoiced object identifier
+    # (BT-18), which has no association to BG-24 and must not carry an attachment.
+    _seen_filenames = set()
+    for att in attachments or []:
+        filename = (getattr(att, "filename", "") or "").strip()
+        if not att.content or not filename or filename.lower() in _seen_filenames:
+            continue  # DE-R-022: attachment filenames must be unique (case-insensitive)
+        _seen_filenames.add(filename.lower())
+        adr = ET.SubElement(inv_el, cac + "AdditionalDocumentReference")
+        _text(adr, cbc + "ID", att.document_id or filename)  # BT-122, required by BR-52
+        _text(adr, cbc + "DocumentDescription", att.description)
+        attachment_el = ET.SubElement(adr, cac + "Attachment")
+        binary_el = ET.SubElement(attachment_el, cbc + "EmbeddedDocumentBinaryObject")
+        binary_el.set("mimeCode", att.mime_code or "application/pdf")
+        binary_el.set("filename", filename)
+        binary_el.text = base64.b64encode(att.content).decode("ascii")
+
     _party(inv_el, "AccountingSupplierParty", supplier)
     _party(inv_el, "AccountingCustomerParty", customer)
 

--- a/app/routes/api_v1_invoices.py
+++ b/app/routes/api_v1_invoices.py
@@ -434,13 +434,23 @@ def send_invoice_peppol_api(invoice_id):
     if not invoice:
         return error_response("Invoice not found", status_code=404)
     try:
-        success, tx, message = PeppolService().send_invoice(
+        service = PeppolService()
+        success, tx, message = service.send_invoice(
             invoice=invoice, triggered_by_user_id=g.api_user.id
         )
     except Exception as e:
         current_app.logger.error(f"API Peppol send failed: {type(e).__name__}: {e}")
         return error_response(f"Failed to send via Peppol: {e}", status_code=502)
-    payload = {"success": success, "message": message, "peppol_tx_id": tx.id if tx else None}
+    payload = {
+        "success": success,
+        "message": message,
+        "peppol_tx_id": tx.id if tx else None,
+        # Whether the human-readable PDF travelled inside the UBL (BG-24). Reported
+        # rather than assumed: a PDF failure degrades to a send without it.
+        "pdf_attached": service.last_pdf_status == "embedded",
+        "pdf_status": service.last_pdf_status,
+        "attachment_filenames": service.last_attachment_filenames,
+    }
     if success:
         return jsonify(payload)
     return jsonify(payload), 400

--- a/app/services/peppol_service.py
+++ b/app/services/peppol_service.py
@@ -1,11 +1,17 @@
 import os
+import re
 import time
 from typing import List, Optional, Tuple
 
 from flask import current_app
 
 from app import db
-from app.integrations.peppol import PeppolParty, build_peppol_ubl_invoice_xml, peppol_enabled
+from app.integrations.peppol import (
+    PeppolAttachment,
+    PeppolParty,
+    build_peppol_ubl_invoice_xml,
+    peppol_enabled,
+)
 from app.integrations.peppol_transport import (
     GenericTransport,
     NativePeppolTransport,
@@ -24,6 +30,79 @@ class PeppolService:
     - sends via access point
     - persists send attempts for audit/retry
     """
+
+    def __init__(self):
+        # Result detail of the most recent send_invoice() call on this instance (routes
+        # build one per request), so callers can report whether the PDF actually
+        # travelled instead of assuming it did.
+        self.last_pdf_status: str = "not_attempted"
+        self.last_attachment_filenames: List[str] = []
+
+    @staticmethod
+    def embed_pdf_enabled() -> bool:
+        """Whether the human-readable invoice PDF is embedded in the UBL (BG-24).
+
+        Default on. Kill-switch for the case where an access point or a recipient
+        chokes on embedded binaries: PEPPOL_EMBED_INVOICE_PDF=false.
+        """
+        return (os.getenv("PEPPOL_EMBED_INVOICE_PDF", "true") or "").strip().lower() in {
+            "1", "true", "yes", "on",
+        }
+
+    def _build_pdf_attachment(self, invoice) -> Optional[PeppolAttachment]:
+        """Render the invoice PDF for embedding as BT-125.
+
+        Never raises: the UBL is the legal original and the PDF is a convenience copy, so
+        a PDF problem degrades to a send without the attachment rather than blocking a
+        valid invoice. Records the outcome in self.last_pdf_status
+        (embedded | disabled | too_large | empty | error) so it can be reported.
+        """
+        if not self.embed_pdf_enabled():
+            self.last_pdf_status = "disabled"
+            return None
+
+        try:
+            from app.utils.pdf_generator import InvoicePDFGenerator
+
+            pdf_bytes = InvoicePDFGenerator(invoice).generate_pdf()
+        except Exception:
+            current_app.logger.exception(
+                "Peppol: invoice PDF generation failed; sending UBL without attachment"
+            )
+            self.last_pdf_status = "error"
+            return None
+
+        if not pdf_bytes:
+            current_app.logger.warning("Peppol: invoice PDF generator returned no bytes")
+            self.last_pdf_status = "empty"
+            return None
+
+        try:
+            max_mb = float(os.getenv("PEPPOL_EMBED_PDF_MAX_MB", "5") or 5)
+        except ValueError:
+            max_mb = 5.0
+        # Wire cost is roughly 1.85x the raw PDF: base64 inside the XML, and most access
+        # points base64 the whole document again into their transport payload.
+        if len(pdf_bytes) > max_mb * 1024 * 1024:
+            current_app.logger.warning(
+                "Peppol: invoice PDF is %.1f MB (cap %.1f MB); sending UBL without attachment",
+                len(pdf_bytes) / 1024 / 1024, max_mb,
+            )
+            self.last_pdf_status = "too_large"
+            return None
+
+        number = (getattr(invoice, "invoice_number", None) or "").strip() or f"invoice-{getattr(invoice, 'id', '')}"
+        safe_name = re.sub(r"[^A-Za-z0-9._-]+", "-", number).strip("-.") or "invoice"
+        filename = f"{safe_name}.pdf"
+        self.last_pdf_status = "embedded"
+        self.last_attachment_filenames = [filename]
+        return PeppolAttachment(
+            document_id=number,
+            filename=filename,
+            mime_code="application/pdf",
+            content=pdf_bytes,
+            description="Commercial invoice (PDF)",
+        )
 
     def _get_sender_party(self) -> PeppolParty:
         settings = Settings.get_settings()
@@ -156,6 +235,8 @@ class PeppolService:
     def send_invoice(
         self, invoice, triggered_by_user_id: Optional[int] = None
     ) -> Tuple[bool, Optional[InvoicePeppolTransmission], str]:
+        self.last_pdf_status = "not_attempted"
+        self.last_attachment_filenames = []
         if not peppol_enabled():
             return False, None, "Peppol is not enabled"
 
@@ -166,8 +247,12 @@ class PeppolService:
             return False, None, str(e)
 
         try:
+            pdf_attachment = self._build_pdf_attachment(invoice)
             ubl_xml, sha256_hex = build_peppol_ubl_invoice_xml(
-                invoice=invoice, supplier=sender, customer=recipient_party
+                invoice=invoice,
+                supplier=sender,
+                customer=recipient_party,
+                attachments=[pdf_attachment] if pdf_attachment else None,
             )
         except Exception as e:
             current_app.logger.exception("Failed to build Peppol UBL XML")

--- a/tests/test_peppol_attachments.py
+++ b/tests/test_peppol_attachments.py
@@ -1,0 +1,144 @@
+"""Peppol BIS Billing 3.0 attachment rules (BG-24 / BT-125).
+
+The invoice PDF is embedded in the UBL itself, so these assertions guard the rules an
+access point validates asynchronously — a wrong element order or a missing mandatory
+attribute is accepted at POST time and only fails later, out of band.
+"""
+import base64
+import xml.etree.ElementTree as ET
+from datetime import date
+from decimal import Decimal
+
+from app.integrations.peppol import (
+    PeppolAttachment,
+    PeppolParty,
+    build_peppol_ubl_invoice_xml,
+)
+
+CBC = "{urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2}"
+CAC = "{urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2}"
+
+# EN 16931 mime code list — the values allowed on BT-125.
+ALLOWED_MIME_CODES = {
+    "application/pdf",
+    "image/png",
+    "image/jpeg",
+    "text/csv",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.oasis.opendocument.spreadsheet",
+}
+
+FAKE_PDF = b"%PDF-1.4\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n%%EOF\n"
+
+
+class _Item:
+    description = "Consulting"
+    quantity = Decimal("1")
+    unit_price = Decimal("100.00")
+    total_amount = Decimal("100.00")
+
+
+class _Invoice:
+    id = 1
+    invoice_number = "INV-2026-0001"
+    issue_date = date(2026, 1, 31)
+    due_date = date(2026, 3, 2)
+    notes = None
+    currency_code = "EUR"
+    buyer_reference = "PO-42"
+    project = None
+    subtotal = Decimal("100.00")
+    tax_rate = Decimal("21")
+    tax_amount = Decimal("21.00")
+    total_amount = Decimal("121.00")
+    items = [_Item()]
+    expenses = None
+    extra_goods = None
+
+
+SUPPLIER = PeppolParty(
+    endpoint_id="0000000000", endpoint_scheme_id="0208", name="Seller BV",
+    tax_id="BE0000000000", address_line="Street 1", country_code="BE",
+)
+CUSTOMER = PeppolParty(
+    endpoint_id="1111111111", endpoint_scheme_id="0208", name="Buyer BV",
+    tax_id="BE1111111111", address_line="Street 2", country_code="BE",
+)
+
+PDF = PeppolAttachment(
+    document_id="INV-2026-0001", filename="INV-2026-0001.pdf",
+    mime_code="application/pdf", content=FAKE_PDF,
+    description="Commercial invoice (PDF)",
+)
+
+
+def _build(attachments=None):
+    xml, _ = build_peppol_ubl_invoice_xml(
+        invoice=_Invoice(), supplier=SUPPLIER, customer=CUSTOMER, attachments=attachments
+    )
+    return ET.fromstring(xml.encode("utf-8"))
+
+
+def _adrs(root):
+    return root.findall(CAC + "AdditionalDocumentReference")
+
+
+def _binary(adr):
+    return adr.find(CAC + "Attachment/" + CBC + "EmbeddedDocumentBinaryObject")
+
+
+def test_attachment_precedes_the_supplier_party():
+    """UBL 2.1 is a sequence: AdditionalDocumentReference comes before the parties."""
+    tags = [c.tag for c in _build([PDF])]
+    assert CAC + "AdditionalDocumentReference" in tags
+    assert tags.index(CAC + "AdditionalDocumentReference") < tags.index(
+        CAC + "AccountingSupplierParty"
+    )
+
+
+def test_pdf_round_trips():
+    binary = _binary(_adrs(_build([PDF]))[0])
+    assert base64.b64decode(binary.text) == FAKE_PDF
+
+
+def test_mandatory_attributes_present_and_on_the_code_list():
+    binary = _binary(_adrs(_build([PDF]))[0])
+    assert binary.get("filename") == "INV-2026-0001.pdf"
+    assert binary.get("mimeCode") in ALLOWED_MIME_CODES
+
+
+def test_document_reference_id_present():
+    """BR-52: each additional supporting document shall contain a document reference."""
+    adr = _adrs(_build([PDF]))[0]
+    assert (adr.find(CBC + "ID").text or "").strip() == "INV-2026-0001"
+
+
+def test_no_document_type_code_emitted():
+    """DocumentTypeCode 130 marks an invoiced object identifier (BT-18), which has no
+    association to BG-24 and must not carry an attachment — so none is emitted."""
+    adr = _adrs(_build([PDF]))[0]
+    assert adr.find(CBC + "DocumentTypeCode") is None
+
+
+def test_duplicate_filenames_are_not_emitted_twice():
+    """DE-R-022: attachment filenames are unique, case-insensitively."""
+    dupe = PeppolAttachment(
+        document_id="X", filename="inv-2026-0001.PDF", mime_code="application/pdf",
+        content=FAKE_PDF,
+    )
+    names = [_binary(a).get("filename", "").lower() for a in _adrs(_build([PDF, dupe]))]
+    assert len(names) == len(set(names))
+
+
+def test_no_attachments_emits_no_element():
+    for arg in (None, []):
+        assert not _adrs(_build(arg))
+
+
+def test_empty_or_unnamed_attachments_are_skipped():
+    empty = PeppolAttachment(document_id="X", filename="a.pdf",
+                             mime_code="application/pdf", content=b"")
+    unnamed = PeppolAttachment(document_id="X", filename="  ",
+                               mime_code="application/pdf", content=FAKE_PDF)
+    assert not _adrs(_build([empty]))
+    assert not _adrs(_build([unnamed]))


### PR DESCRIPTION
### Why

Peppol carries **one** business document per message, so a PDF cannot travel *beside* the UBL — it has to be embedded *inside* it. Today TimeTracker sends structured data only, and recipients keep asking for the human-readable copy (this came from a real customer of ours). The November 2025 BIS 3.0 release explicitly calls out embedding PDFs this way for hybrid PDF + structured-data workflows.

### What

`PeppolAttachment` + an `attachments` argument on `build_peppol_ubl_invoice_xml()`, emitting:

```xml
<cac:AdditionalDocumentReference>
  <cbc:ID>INV-2026-0001</cbc:ID>
  <cbc:DocumentDescription>Commercial invoice (PDF)</cbc:DocumentDescription>
  <cac:Attachment>
    <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf"
        filename="INV-2026-0001.pdf">JVBERi0…</cbc:EmbeddedDocumentBinaryObject>
  </cac:Attachment>
</cac:AdditionalDocumentReference>
```

`PeppolService` renders the invoice PDF via `InvoicePDFGenerator` and passes it in.

### The three rules that are easy to get wrong

| Rule | Handling |
|---|---|
| **Placement** | UBL 2.1 is an XSD *sequence*: emitted after the document references and **before** `Signature`/the parties. Same class of bug as #717 — accepted at POST time, fatal at async validation. |
| **No `cbc:DocumentTypeCode`** | Code `130` marks an *invoiced object identifier* (BT-18), which has no association to BG-24 and must not carry an attachment. |
| **`@mimeCode` + `@filename`** | Both mandatory on BT-125; filenames unique case-insensitively (DE-R-022). Empty, unnamed and duplicate attachments are skipped rather than emitted invalid. |

### Degrades, never blocks

If PDF generation fails the invoice is still sent, **without** the attachment — the UBL is the legal original, so a missing PDF is a nuisance while a blocked send is a payment problem. The outcome is never silent: `last_pdf_status` (`embedded` / `disabled` / `too_large` / `empty` / `error`) and the send API returns `pdf_attached` / `pdf_status` / `attachment_filenames`, so a degraded send cannot be mistaken for a clean one.

### Configuration

| Env | Default | Purpose |
|---|---|---|
| `PEPPOL_EMBED_INVOICE_PDF` | `true` | Kill-switch if an AP or recipient chokes on embedded binaries |
| `PEPPOL_EMBED_PDF_MAX_MB` | `5` | Runaway guard — wire cost is ~1.85x the raw PDF (base64 into the XML, then the XML into the transport payload) |

### Testing

8 new tests in `tests/test_peppol_attachments.py` — ordering, mandatory attributes, BR-52, DE-R-022, the `DocumentTypeCode` exclusion, base64 round-trip, and the skip paths. `test_peppol_attachments.py` + `test_peppol_service.py` + `test_peppol_identifiers.py`: **20 passed**.

Verified live against a real access point (Peppyrus): an 83 KB PDF embedded in a 115 KB UBL reached folder `Sent` with **zero FATAL validation rules**, and the PDF was then extracted back out of the access point's own stored copy of the transmitted document and opened intact.

Follows #712, #713, #717 and #718. Independent of them — this branch is cut from current `main`.