### PR TITLE
Fix/start timer ux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Mobile start timer flow** — Client, project, and task selection in the start timer sheet now use one consistent searchable picker; picking a client filters the project list to that client and picking a project filters tasks accordingly. Typing an unknown name offers inline "Create …" for clients, projects, and tasks via the existing v1 endpoints. The projects screen is sorted by most recently used (`last_used_at`) so recent work can be restarted with one tap.
+- **Mobile start timer flow** — Client, project, and task selection in the start timer sheet now use one consistent searchable picker; picking a client filters the project list to that client and picking a project filters tasks accordingly. Projects can also be picked directly without choosing a client first, which then auto-fills the client. Typing an unknown name offers inline "Create …" for clients, projects, and tasks via the existing v1 endpoints. The projects screen is sorted by most recently used (`last_used_at`) so recent work can be restarted with one tap.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Mobile start timer flow** — Client, project, and task selection in the start timer sheet now use one consistent searchable picker; picking a client filters the project list to that client and picking a project filters tasks accordingly. Typing an unknown name offers inline "Create …" for clients, projects, and tasks via the existing v1 endpoints. The projects screen is sorted by most recently used (`last_used_at`) so recent work can be restarted with one tap.
+
+### Fixed
+
+- **Mobile start timer crash** — Two `FloatingActionButton`s with the default Hero tag coexisted in the home screen's `IndexedStack`, turning the screen red whenever a route was pushed on top (e.g. the start timer sheet); the Entries tab FAB now has a unique `heroTag`.
+- **Mobile inline creation selection** — The v1 create endpoints wrap the payload (`{"message": …, "<entity>": {…}}`); unwrapping it ensures a newly created client/project/task is selected immediately in the start timer sheet.
+- **Mobile stop/pause flicker** — Background timer polling no longer toggles `isLoading`, which disabled the Stop and Pause buttons for the duration of each 5-second sync; the flag is now reserved for user-initiated actions.
+
 ## [5.13.1] - 2026-08-26
 
 ### Changed

--- a/mobile/lib/data/models/project.dart
+++ b/mobile/lib/data/models/project.dart
@@ -7,6 +7,7 @@ class Project {
   final bool billable;
   final DateTime? createdAt;
   final DateTime? updatedAt;
+  final DateTime? lastUsedAt;
 
   const Project({
     required this.id,
@@ -17,6 +18,7 @@ class Project {
     this.billable = true,
     this.createdAt,
     this.updatedAt,
+    this.lastUsedAt,
   });
 
   factory Project.fromJson(Map<String, dynamic> json) {
@@ -38,6 +40,7 @@ class Project {
       billable: json['billable'] == true,
       createdAt: _parseDt(json['created_at']),
       updatedAt: _parseDt(json['updated_at']),
+      lastUsedAt: _parseDt(json['last_used_at']),
     );
   }
 
@@ -50,6 +53,7 @@ class Project {
         'billable': billable,
         'created_at': createdAt?.toIso8601String(),
         'updated_at': updatedAt?.toIso8601String(),
+        'last_used_at': lastUsedAt?.toIso8601String(),
       };
 
   static DateTime? _parseDt(dynamic v) {

--- a/mobile/lib/presentation/providers/timer_provider.dart
+++ b/mobile/lib/presentation/providers/timer_provider.dart
@@ -77,17 +77,21 @@ class TimerNotifier extends StateNotifier<TimerState> {
   void _startPolling() {
     Future.delayed(const Duration(seconds: 5), () {
       if (state.isActive && repository != null) {
-        _loadTimerStatus();
+        _loadTimerStatus(silent: true);
         _startPolling();
       }
     });
   }
 
-  Future<void> _loadTimerStatus() async {
+  /// [silent] skips the isLoading flag so background polls don't gray out
+  /// the stop/pause buttons while a timer is running.
+  Future<void> _loadTimerStatus({bool silent = false}) async {
     if (repository == null) return;
 
     try {
-      state = state.copyWith(isLoading: true, clearError: true);
+      if (!silent) {
+        state = state.copyWith(isLoading: true, clearError: true);
+      }
       final status = await repository!.getTimerStatusDetailed();
       final timer = status.timer;
       state = state.copyWith(
@@ -104,7 +108,9 @@ class TimerNotifier extends StateNotifier<TimerState> {
       );
       await _syncNotificationWithState();
     } catch (e) {
-      state = state.copyWith(isLoading: false, error: e.toString());
+      state = silent
+          ? state.copyWith(isLoading: false)
+          : state.copyWith(isLoading: false, error: e.toString());
     }
   }
 

--- a/mobile/lib/presentation/screens/projects_screen.dart
+++ b/mobile/lib/presentation/screens/projects_screen.dart
@@ -34,11 +34,28 @@ class _ProjectsScreenState extends ConsumerState<ProjectsScreen> {
   }
 
   List<Project> _filterProjects(List<Project> projects, String query) {
-    if (query.isEmpty) return projects;
-    return projects.where((project) {
+    if (query.isEmpty) {
+      return _sortByRecent(projects);
+    }
+    return _sortByRecent(projects.where((project) {
       return project.name.toLowerCase().contains(query.toLowerCase()) ||
           (project.client ?? '').toLowerCase().contains(query.toLowerCase());
-    }).toList();
+    }).toList());
+  }
+
+  // Most recently booked projects first so the last project worked on is at
+  // the top and can be restarted with a single tap.
+  List<Project> _sortByRecent(List<Project> projects) {
+    final sorted = [...projects];
+    sorted.sort((a, b) {
+      final aDate = a.lastUsedAt;
+      final bDate = b.lastUsedAt;
+      if (aDate == null && bDate == null) return a.name.compareTo(b.name);
+      if (aDate == null) return 1;
+      if (bDate == null) return -1;
+      return bDate.compareTo(aDate);
+    });
+    return sorted;
   }
 
   Future<void> _startTimerForProject(Project project) async {

--- a/mobile/lib/presentation/screens/time_entries_screen.dart
+++ b/mobile/lib/presentation/screens/time_entries_screen.dart
@@ -51,6 +51,10 @@ class _TimeEntriesScreenState extends ConsumerState<TimeEntriesScreen> {
         child: _buildBody(entriesState),
       ),
       floatingActionButton: FloatingActionButton(
+        // Lives inside the home screen's IndexedStack alongside the dashboard
+        // FAB; without a unique tag the two default Hero tags crash any
+        // route pushed on top (e.g. the start timer sheet).
+        heroTag: 'timeEntriesFab',
         onPressed: () => _showAddEntryDialog(),
         child: const Icon(Icons.add),
       ),

--- a/mobile/lib/presentation/widgets/searchable_picker_field.dart
+++ b/mobile/lib/presentation/widgets/searchable_picker_field.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+
+/// An item shown in a [SearchablePickerField].
+class PickerItem<T> {
+  final T value;
+  final String title;
+  final String? subtitle;
+
+  const PickerItem({required this.value, required this.title, this.subtitle});
+}
+
+/// A form-field style searchable picker.
+///
+/// Renders like a `DropdownButtonFormField` (label + prefix icon) but opens a
+/// searchable suggestion list, so every selection step looks and behaves the
+/// same. When [onCreate] is provided and the typed text matches no item, a
+/// 'Create "X"' row is offered at the top of the list.
+class SearchablePickerField<T> extends StatefulWidget {
+  final String label;
+  final IconData icon;
+  final List<PickerItem<T>> items;
+  final PickerItem<T>? selected;
+  final ValueChanged<PickerItem<T>>? onSelected;
+
+  /// Called when the user taps the clear (x) button on a selected value.
+  final VoidCallback? onClear;
+
+  /// Called when the user types a name that matches no item.
+  /// Returns the newly created item (or null on failure/abort).
+  final Future<PickerItem<T>?> Function(String name)? onCreate;
+
+  final bool enabled;
+  final bool isLoading;
+  final String? error;
+  final VoidCallback? onRetry;
+  final String searchHint;
+  final String emptyText;
+
+  const SearchablePickerField({
+    super.key,
+    required this.label,
+    required this.icon,
+    required this.items,
+    required this.onSelected,
+    this.selected,
+    this.onClear,
+    this.onCreate,
+    this.enabled = true,
+    this.isLoading = false,
+    this.error,
+    this.onRetry,
+    this.searchHint = 'Search',
+    this.emptyText = 'No matches',
+  });
+
+  @override
+  State<SearchablePickerField<T>> createState() => _SearchablePickerFieldState<T>();
+}
+
+class _SearchablePickerFieldState<T> extends State<SearchablePickerField<T>> {
+  final SearchController _searchController = SearchController();
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  List<PickerItem<T>> _matches(String query) {
+    final q = query.trim().toLowerCase();
+    if (q.isEmpty) return widget.items;
+    return widget.items
+        .where((i) =>
+            i.title.toLowerCase().contains(q) ||
+            (i.subtitle ?? '').toLowerCase().contains(q))
+        .toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final hasSelection = widget.selected != null;
+
+    return SearchAnchor(
+      searchController: _searchController,
+      viewHintText: widget.searchHint,
+      builder: (context, controller) {
+        return InkWell(
+          onTap: widget.enabled ? controller.openView : null,
+          borderRadius: BorderRadius.circular(12),
+          child: InputDecorator(
+            decoration: InputDecoration(
+              labelText: widget.label,
+              prefixIcon: Icon(widget.icon),
+              suffixIcon: hasSelection && widget.enabled && widget.onClear != null
+                  ? IconButton(
+                      icon: const Icon(Icons.clear),
+                      tooltip: 'Clear',
+                      onPressed: () {
+                        _searchController.clear();
+                        widget.onClear!();
+                      },
+                    )
+                  : (widget.isLoading
+                      ? const SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: Padding(
+                            padding: EdgeInsets.all(8),
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          ),
+                        )
+                      : widget.enabled
+                          ? const Icon(Icons.arrow_drop_down)
+                          : null),
+              enabled: widget.enabled,
+            ),
+            child: Text(
+              hasSelection ? widget.selected!.title : '',
+              style: theme.textTheme.bodyLarge,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        );
+      },
+      suggestionsBuilder: (context, controller) {
+        final query = controller.text.trim();
+        final matches = _matches(controller.text);
+
+        if (widget.isLoading && widget.items.isEmpty) {
+          return const [ListTile(title: Text('Loading...'))];
+        }
+        if (widget.error != null && widget.items.isEmpty) {
+          return [
+            ListTile(
+              title: const Text('Could not load'),
+              subtitle: Text(widget.error!),
+              trailing: widget.onRetry != null
+                  ? TextButton(onPressed: widget.onRetry, child: const Text('Retry'))
+                  : null,
+            ),
+          ];
+        }
+
+        final suggestions = <Widget>[];
+
+        if (widget.onCreate != null &&
+            query.isNotEmpty &&
+            matches.isEmpty) {
+          suggestions.add(ListTile(
+            leading: const Icon(Icons.add_circle_outline),
+            title: Text('Create "$query"'),
+            onTap: () async {
+              controller.closeView('');
+              final created = await widget.onCreate!(query);
+              if (created != null) {
+                widget.onSelected?.call(created);
+              }
+            },
+          ));
+        }
+
+        if (matches.isEmpty && suggestions.isEmpty) {
+          return [ListTile(title: Text(widget.emptyText))];
+        }
+
+        suggestions.addAll(matches.map((item) => ListTile(
+              leading: CircleAvatar(
+                child: Text(
+                  (item.title.isNotEmpty ? item.title[0] : '?').toUpperCase(),
+                  style: const TextStyle(fontWeight: FontWeight.w700),
+                ),
+              ),
+              title: Text(item.title),
+              subtitle:
+                  (item.subtitle == null || item.subtitle!.isEmpty) ? null : Text(item.subtitle!),
+              onTap: () {
+                controller.closeView(item.title);
+                widget.onSelected?.call(item);
+              },
+            )));
+
+        return suggestions;
+      },
+    );
+  }
+}

--- a/mobile/lib/presentation/widgets/start_timer_sheet.dart
+++ b/mobile/lib/presentation/widgets/start_timer_sheet.dart
@@ -164,12 +164,19 @@ class _StartTimerSheetState extends ConsumerState<StartTimerSheet> {
     return projects.where((p) => p.clientId == _selectedClient!.id).toList();
   }
 
+  // The v1 create endpoints wrap the payload: {"message": ..., "<key>": {...}}.
+  Map<String, dynamic> _unwrap(Map<String, dynamic> res, String key) {
+    final nested = res[key];
+    if (nested is Map) return Map<String, dynamic>.from(nested);
+    return res;
+  }
+
   Future<PickerItem<_ClientItem>?> _createClient(String name) async {
     final api = ref.read(apiClientProvider).valueOrNull;
     if (api == null || _creating) return null;
     setState(() => _creating = true);
     try {
-      final created = await api.createClient(name: name);
+      final created = _unwrap(await api.createClient(name: name), 'client');
       final item = _ClientItem(
         id: ((created['id'] as num?) ?? 0).toInt(),
         name: created['name']?.toString() ?? name,
@@ -199,10 +206,8 @@ class _StartTimerSheetState extends ConsumerState<StartTimerSheet> {
     if (api == null || _creating || _selectedClient == null) return null;
     setState(() => _creating = true);
     try {
-      final created = await api.createProject(
-        name: name,
-        clientId: _selectedClient!.id,
-      );
+      final created =
+          _unwrap(await api.createProject(name: name, clientId: _selectedClient!.id), 'project');
       final project = Project.fromJson(created);
       if (!mounted) return null;
       setState(() {
@@ -229,9 +234,9 @@ class _StartTimerSheetState extends ConsumerState<StartTimerSheet> {
     if (api == null || _creating || _selectedProject == null) return null;
     setState(() => _creating = true);
     try {
-      final created = await api.createTask(
-        projectId: _selectedProject!.id,
-        name: name,
+      final created = _unwrap(
+        await api.createTask(projectId: _selectedProject!.id, name: name),
+        'task',
       );
       final task = task_model.Task.fromJson(created);
       if (!mounted) return null;

--- a/mobile/lib/presentation/widgets/start_timer_sheet.dart
+++ b/mobile/lib/presentation/widgets/start_timer_sheet.dart
@@ -69,11 +69,6 @@ class _StartTimerSheetState extends ConsumerState<StartTimerSheet> {
       _loadClients();
       _tryApplyInitialProject(ref.read(projectsProvider).projects);
     });
-
-    ref.listen<ProjectsState>(projectsProvider, (previous, next) {
-      if (!mounted) return;
-      _tryApplyInitialProject(next.projects);
-    });
   }
 
   @override
@@ -313,6 +308,13 @@ class _StartTimerSheetState extends ConsumerState<StartTimerSheet> {
 
   @override
   Widget build(BuildContext context) {
+    // Listen within build so initial project selection applies as soon as
+    // projects finish loading.
+    ref.listen<ProjectsState>(projectsProvider, (previous, next) {
+      if (!mounted) return;
+      _tryApplyInitialProject(next.projects);
+    });
+
     final apiClientAsync = ref.watch(apiClientProvider);
     final projectsState = ref.watch(projectsProvider);
     final tasksState = ref.watch(tasksProvider);

--- a/mobile/lib/presentation/widgets/start_timer_sheet.dart
+++ b/mobile/lib/presentation/widgets/start_timer_sheet.dart
@@ -4,11 +4,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:timetracker_mobile/core/theme/app_tokens.dart';
 import 'package:timetracker_mobile/data/models/project.dart';
+import 'package:timetracker_mobile/data/models/task.dart' as task_model;
 import 'package:timetracker_mobile/presentation/providers/api_provider.dart';
 import 'package:timetracker_mobile/presentation/providers/projects_provider.dart';
 import 'package:timetracker_mobile/presentation/providers/tasks_provider.dart';
 import 'package:timetracker_mobile/presentation/providers/time_entry_requirements_provider.dart';
 import 'package:timetracker_mobile/presentation/providers/timer_provider.dart';
+import 'package:timetracker_mobile/presentation/widgets/searchable_picker_field.dart';
 
 Future<void> showStartTimerSheet(
   BuildContext context, {
@@ -24,6 +26,13 @@ Future<void> showStartTimerSheet(
       initialClientId: initialClientId,
     ),
   );
+}
+
+class _ClientItem {
+  final int id;
+  final String name;
+
+  const _ClientItem({required this.id, required this.name});
 }
 
 class StartTimerSheet extends ConsumerStatefulWidget {
@@ -42,19 +51,18 @@ class StartTimerSheet extends ConsumerStatefulWidget {
 
 class _StartTimerSheetState extends ConsumerState<StartTimerSheet> {
   final _notesController = TextEditingController();
-  final SearchController _projectSearchController = SearchController();
 
-  int? _selectedClientId;
-  String? _selectedClientName;
-  int? _selectedProjectId;
-  int? _selectedTaskId;
-  List<Map<String, dynamic>> _clients = [];
+  _ClientItem? _selectedClient;
+  Project? _selectedProject;
+  task_model.Task? _selectedTask;
+  List<_ClientItem> _clients = [];
   bool _clientsLoading = false;
+  String? _clientsError;
+  bool _creating = false;
 
   @override
   void initState() {
     super.initState();
-    _selectedClientId = widget.initialClientId;
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       ref.read(projectsProvider.notifier).loadProjects();
@@ -71,79 +79,186 @@ class _StartTimerSheetState extends ConsumerState<StartTimerSheet> {
   @override
   void dispose() {
     _notesController.dispose();
-    _projectSearchController.dispose();
     super.dispose();
   }
 
   Future<void> _loadClients() async {
     final api = ref.read(apiClientProvider).valueOrNull;
     if (api == null) return;
-    setState(() => _clientsLoading = true);
+    setState(() {
+      _clientsLoading = true;
+      _clientsError = null;
+    });
     try {
       final res = await api.getClients(status: 'active', perPage: 100);
       final list = (res['clients'] as List<dynamic>? ?? [])
           .whereType<Map>()
-          .map((c) => Map<String, dynamic>.from(c))
+          .map((c) => _ClientItem(
+                id: ((c['id'] as num?) ?? 0).toInt(),
+                name: c['name']?.toString() ?? '',
+              ))
           .toList();
       if (!mounted) return;
       setState(() {
         _clients = list;
         _clientsLoading = false;
-        if (_selectedClientId != null) {
-          final match = list.where((c) => (c['id'] as num?)?.toInt() == _selectedClientId);
-          if (match.isNotEmpty) {
-            _selectedClientName = match.first['name']?.toString();
-          }
+        if (_selectedClient == null && widget.initialClientId != null) {
+          final match = list.where((c) => c.id == widget.initialClientId);
+          if (match.isNotEmpty) _selectedClient = match.first;
         }
       });
-    } catch (_) {
-      if (mounted) setState(() => _clientsLoading = false);
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _clientsLoading = false;
+          _clientsError = e.toString();
+        });
+      }
     }
   }
 
   void _tryApplyInitialProject(List<Project> projects) {
-    if (_selectedProjectId != null) return;
+    if (_selectedProject != null) return;
     final initialId = widget.initialProjectId;
     if (initialId == null) return;
 
     final match = projects.where((p) => p.id == initialId).toList();
     if (match.isEmpty) return;
 
-    _selectProject(match.first);
+    _applyProject(match.first);
   }
 
-  Future<void> _selectClient(int? clientId, {String? name}) async {
+  void _applyProject(Project project) {
+    _selectedProject = project;
+    _selectedTask = null;
+    if (project.clientId != null && _selectedClient == null) {
+      final clientMatch =
+          _clients.where((c) => c.id == project.clientId).toList();
+      _selectedClient = clientMatch.isNotEmpty
+          ? clientMatch.first
+          : _ClientItem(id: project.clientId!, name: project.client ?? '');
+    }
+    ref.read(tasksProvider.notifier).loadTasks(projectId: project.id);
+  }
+
+  void _selectClient(_ClientItem? client) {
     setState(() {
-      _selectedClientId = clientId;
-      _selectedClientName = name;
-      _selectedProjectId = null;
-      _selectedTaskId = null;
-      _projectSearchController.text = '';
+      _selectedClient = client;
+      // Changing the client invalidates project and task selections.
+      _selectedProject = null;
+      _selectedTask = null;
     });
   }
 
-  Future<void> _selectProject(Project project) async {
+  void _selectProject(Project? project) {
     setState(() {
-      _selectedProjectId = project.id;
-      _selectedTaskId = null;
-      _projectSearchController.text = project.name;
-      if (project.clientId != null) {
-        _selectedClientId = project.clientId;
-        _selectedClientName = project.client;
+      _selectedProject = project;
+      _selectedTask = null;
+    });
+    if (project != null) {
+      ref.read(tasksProvider.notifier).loadTasks(projectId: project.id);
+    }
+  }
+
+  void _selectTask(task_model.Task? task) {
+    setState(() => _selectedTask = task);
+  }
+
+  List<Project> _clientProjects(List<Project> projects) {
+    if (_selectedClient == null) return projects;
+    return projects.where((p) => p.clientId == _selectedClient!.id).toList();
+  }
+
+  Future<PickerItem<_ClientItem>?> _createClient(String name) async {
+    final api = ref.read(apiClientProvider).valueOrNull;
+    if (api == null || _creating) return null;
+    setState(() => _creating = true);
+    try {
+      final created = await api.createClient(name: name);
+      final item = _ClientItem(
+        id: ((created['id'] as num?) ?? 0).toInt(),
+        name: created['name']?.toString() ?? name,
+      );
+      if (!mounted) return null;
+      setState(() {
+        _clients = [..._clients, item];
+        _selectedClient = item;
+        _selectedProject = null;
+        _selectedTask = null;
+        _creating = false;
+      });
+      return PickerItem(value: item, title: item.name);
+    } catch (e) {
+      if (mounted) {
+        setState(() => _creating = false);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Could not create client: $e')),
+        );
       }
-    });
-    await ref.read(tasksProvider.notifier).loadTasks(projectId: project.id);
+      return null;
+    }
   }
 
-  List<Project> _filteredProjects(List<Project> projects) {
-    if (_selectedClientId == null) return projects;
-    return projects
-        .where((p) => p.clientId == null || p.clientId == _selectedClientId)
-        .toList();
+  Future<PickerItem<Project>?> _createProject(String name) async {
+    final api = ref.read(apiClientProvider).valueOrNull;
+    if (api == null || _creating || _selectedClient == null) return null;
+    setState(() => _creating = true);
+    try {
+      final created = await api.createProject(
+        name: name,
+        clientId: _selectedClient!.id,
+      );
+      final project = Project.fromJson(created);
+      if (!mounted) return null;
+      setState(() {
+        _selectedProject = project;
+        _selectedTask = null;
+        _creating = false;
+      });
+      ref.read(projectsProvider.notifier).refresh();
+      ref.read(tasksProvider.notifier).loadTasks(projectId: project.id);
+      return PickerItem(value: project, title: project.name, subtitle: _selectedClient!.name);
+    } catch (e) {
+      if (mounted) {
+        setState(() => _creating = false);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Could not create project: $e')),
+        );
+      }
+      return null;
+    }
+  }
+
+  Future<PickerItem<task_model.Task>?> _createTask(String name) async {
+    final api = ref.read(apiClientProvider).valueOrNull;
+    if (api == null || _creating || _selectedProject == null) return null;
+    setState(() => _creating = true);
+    try {
+      final created = await api.createTask(
+        projectId: _selectedProject!.id,
+        name: name,
+      );
+      final task = task_model.Task.fromJson(created);
+      if (!mounted) return null;
+      setState(() {
+        _selectedTask = task;
+        _creating = false;
+      });
+      ref.read(tasksProvider.notifier).loadTasks(projectId: _selectedProject!.id);
+      return PickerItem(value: task, title: task.name);
+    } catch (e) {
+      if (mounted) {
+        setState(() => _creating = false);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Could not create task: $e')),
+        );
+      }
+      return null;
+    }
   }
 
   Future<void> _handleStart() async {
-    if (_selectedProjectId == null && _selectedClientId == null) {
+    if (_selectedProject == null && _selectedClient == null) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Please select a client or project')),
       );
@@ -151,9 +266,9 @@ class _StartTimerSheetState extends ConsumerState<StartTimerSheet> {
     }
 
     final requirements = await ref.read(timeEntryRequirementsProvider.future);
-    if (_selectedProjectId != null &&
+    if (_selectedProject != null &&
         requirements.requireTask &&
-        _selectedTaskId == null) {
+        _selectedTask == null) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('A task must be selected when logging time for a project')),
       );
@@ -180,9 +295,9 @@ class _StartTimerSheetState extends ConsumerState<StartTimerSheet> {
     }
 
     await ref.read(timerProvider.notifier).startTimer(
-          projectId: _selectedProjectId,
-          clientId: _selectedProjectId == null ? _selectedClientId : null,
-          taskId: _selectedTaskId,
+          projectId: _selectedProject?.id,
+          clientId: _selectedProject == null ? _selectedClient?.id : null,
+          taskId: _selectedTask?.id,
           notes: notes.isEmpty ? null : notes,
         );
 
@@ -217,8 +332,9 @@ class _StartTimerSheetState extends ConsumerState<StartTimerSheet> {
     final bottomInset = MediaQuery.of(context).viewInsets.bottom;
     final maxHeight = MediaQuery.of(context).size.height * 0.9;
 
-    final canStart = isApiReady && !isApiLoading && !timerState.isLoading;
-    final filteredProjects = _filteredProjects(projectsState.projects);
+    final canStart =
+        isApiReady && !isApiLoading && !timerState.isLoading && !_creating;
+    final clientProjects = _clientProjects(projectsState.projects);
 
     return ConstrainedBox(
       constraints: BoxConstraints(maxHeight: maxHeight),
@@ -229,234 +345,175 @@ class _StartTimerSheetState extends ConsumerState<StartTimerSheet> {
           top: AppSpacing.sm,
           bottom: math.max(AppSpacing.md, bottomInset),
         ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Row(
-              children: [
-                Text('Start timer', style: theme.textTheme.titleLarge),
-                const Spacer(),
-                IconButton(
-                  onPressed: (timerState.isLoading || isApiLoading) ? null : () => Navigator.of(context).pop(),
-                  icon: const Icon(Icons.close),
-                  tooltip: 'Close',
-                ),
-              ],
-            ),
-            const SizedBox(height: AppSpacing.sm),
-            if (isApiLoading)
-              const Padding(
-                padding: EdgeInsets.symmetric(vertical: AppSpacing.lg),
-                child: Center(child: CircularProgressIndicator()),
-              )
-            else if (!isApiReady)
-              Container(
-                padding: const EdgeInsets.all(AppSpacing.md),
-                decoration: BoxDecoration(
-                  color: cs.errorContainer,
-                  borderRadius: AppRadii.brMd,
-                ),
-                child: Text(
-                  'Not connected to server. Check settings and try again.',
-                  style: TextStyle(color: cs.onErrorContainer),
-                ),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Row(
+                children: [
+                  Text('Start timer', style: theme.textTheme.titleLarge),
+                  const Spacer(),
+                  IconButton(
+                    onPressed: (timerState.isLoading || isApiLoading) ? null : () => Navigator.of(context).pop(),
+                    icon: const Icon(Icons.close),
+                    tooltip: 'Close',
+                  ),
+                ],
               ),
-            const SizedBox(height: AppSpacing.md),
-            DropdownButtonFormField<int>(
-              key: ValueKey('client_$_selectedClientId'),
-              decoration: const InputDecoration(
-                labelText: 'Client (optional)',
-                prefixIcon: Icon(Icons.business_outlined),
+              const SizedBox(height: AppSpacing.sm),
+              if (isApiLoading)
+                const Padding(
+                  padding: EdgeInsets.symmetric(vertical: AppSpacing.lg),
+                  child: Center(child: CircularProgressIndicator()),
+                )
+              else if (!isApiReady)
+                Container(
+                  padding: const EdgeInsets.all(AppSpacing.md),
+                  decoration: BoxDecoration(
+                    color: cs.errorContainer,
+                    borderRadius: AppRadii.brMd,
+                  ),
+                  child: Text(
+                    'Not connected to server. Check settings and try again.',
+                    style: TextStyle(color: cs.onErrorContainer),
+                  ),
+                ),
+              const SizedBox(height: AppSpacing.md),
+              SearchablePickerField<_ClientItem>(
+                label: 'Client (optional)',
+                icon: Icons.business_outlined,
+                searchHint: 'Search clients',
+                emptyText: 'No clients found',
+                isLoading: _clientsLoading,
+                error: _clientsError,
+                onRetry: _loadClients,
+                enabled: isApiReady && !_clientsLoading && !_creating,
+                items: _clients
+                    .map((c) => PickerItem(value: c, title: c.name))
+                    .toList(),
+                selected: _selectedClient == null
+                    ? null
+                    : PickerItem(value: _selectedClient!, title: _selectedClient!.name),
+                onSelected: (item) => _selectClient(item.value),
+                onClear: () => _selectClient(null),
+                onCreate: _createClient,
               ),
-              initialValue: _selectedClientId,
-              items: [
-                const DropdownMenuItem<int>(value: null, child: Text('Any client')),
-                ..._clients.map((c) {
-                  final id = (c['id'] as num).toInt();
-                  return DropdownMenuItem<int>(
-                    value: id,
-                    child: Text(c['name']?.toString() ?? 'Client #$id'),
-                  );
-                }),
-              ],
-              onChanged: _clientsLoading
-                  ? null
-                  : (value) {
-                      String? name;
-                      if (value != null) {
-                        for (final c in _clients) {
-                          if ((c['id'] as num?)?.toInt() == value) {
-                            name = c['name']?.toString();
-                            break;
-                          }
-                        }
-                      }
-                      _selectClient(value, name: name ?? _selectedClientName);
-                    },
-            ),
-            const SizedBox(height: AppSpacing.md),
-            SearchAnchor(
-              searchController: _projectSearchController,
-              viewHintText: 'Search projects',
-              builder: (context, controller) {
-                return SearchBar(
-                  controller: controller,
-                  onTap: controller.openView,
-                  onChanged: (_) => controller.openView(),
-                  leading: const Icon(Icons.folder_outlined),
-                  hintText: _selectedClientId != null
-                      ? 'Project (optional for this client)'
-                      : 'Select project',
-                  trailing: [
-                    if (_selectedProjectId != null)
-                      IconButton(
-                        onPressed: () {
-                          setState(() {
-                            _selectedProjectId = null;
-                            _selectedTaskId = null;
-                            _projectSearchController.text = '';
-                          });
-                        },
-                        icon: const Icon(Icons.clear),
-                        tooltip: 'Clear project',
+              const SizedBox(height: AppSpacing.md),
+              SearchablePickerField<Project>(
+                key: ValueKey('projects_${_selectedClient?.id}'),
+                label: _selectedClient == null
+                    ? 'Project (select a client first)'
+                    : 'Project (optional for this client)',
+                icon: Icons.folder_outlined,
+                searchHint: 'Search projects',
+                emptyText: _selectedClient == null
+                    ? 'Select a client first'
+                    : 'No projects for this client',
+                enabled: _selectedClient != null && !_creating,
+                isLoading: projectsState.isLoading,
+                error: projectsState.error,
+                onRetry: () => ref.read(projectsProvider.notifier).loadProjects(),
+                items: clientProjects
+                    .map((p) => PickerItem(
+                          value: p,
+                          title: p.name,
+                          subtitle: p.client,
+                        ))
+                    .toList(),
+                selected: _selectedProject == null
+                    ? null
+                    : PickerItem(
+                        value: _selectedProject!,
+                        title: _selectedProject!.name,
+                        subtitle: _selectedProject!.client,
                       ),
-                  ],
-                );
-              },
-              suggestionsBuilder: (context, controller) {
-                final query = controller.text.trim().toLowerCase();
-                final projects = filteredProjects;
-                final matches = query.isEmpty
-                    ? projects
-                    : projects.where((p) {
-                        final client = (p.client ?? '').toLowerCase();
-                        return p.name.toLowerCase().contains(query) || client.contains(query);
-                      }).toList();
-
-                if (projectsState.isLoading && projects.isEmpty) {
-                  return const [ListTile(title: Text('Loading projects...'))];
-                }
-
-                if (projectsState.error != null && projects.isEmpty) {
-                  return [
-                    ListTile(
-                      title: const Text('Could not load projects'),
-                      subtitle: Text(projectsState.error!),
-                      trailing: TextButton(
-                        onPressed: () => ref.read(projectsProvider.notifier).loadProjects(),
-                        child: const Text('Retry'),
-                      ),
-                    ),
-                  ];
-                }
-
-                if (matches.isEmpty) {
-                  return [
-                    ListTile(
-                      title: Text(
-                        _selectedClientId != null
-                            ? 'No projects for this client — start client-only'
-                            : 'No matching projects',
-                      ),
-                    ),
-                  ];
-                }
-
-                return matches.map((p) {
-                  return ListTile(
-                    leading: CircleAvatar(
-                      child: Text(
-                        (p.name.isNotEmpty ? p.name[0] : '?').toUpperCase(),
-                        style: const TextStyle(fontWeight: FontWeight.w700),
-                      ),
-                    ),
-                    title: Text(p.name),
-                    subtitle: (p.client == null || p.client!.isEmpty) ? null : Text(p.client!),
-                    onTap: () async {
-                      controller.closeView(p.name);
-                      await _selectProject(p);
-                    },
-                  );
-                });
-              },
-            ),
-            const SizedBox(height: AppSpacing.md),
-            DropdownButtonFormField<int>(
-              key: ValueKey('task_$_selectedTaskId'),
-              decoration: InputDecoration(
-                labelText: requirementsAsync.valueOrNull?.requireTask == true
+                onSelected: (item) => _selectProject(item.value),
+                onClear: () => _selectProject(null),
+                onCreate: _selectedClient == null ? null : _createProject,
+              ),
+              const SizedBox(height: AppSpacing.md),
+              SearchablePickerField<task_model.Task>(
+                key: ValueKey('tasks_${_selectedProject?.id}'),
+                label: requirementsAsync.valueOrNull?.requireTask == true
                     ? 'Task *'
                     : 'Task (optional)',
-                prefixIcon: const Icon(Icons.task_outlined),
+                icon: Icons.task_outlined,
+                searchHint: 'Search tasks',
+                emptyText: _selectedProject == null
+                    ? 'Select a project first'
+                    : 'No tasks for this project',
+                enabled: _selectedProject != null && !_creating,
+                isLoading: tasksState.isLoading,
+                error: tasksState.error,
+                onRetry: _selectedProject == null
+                    ? null
+                    : () => ref
+                        .read(tasksProvider.notifier)
+                        .loadTasks(projectId: _selectedProject!.id),
+                items: tasksState.tasks
+                    .map((t) => PickerItem(value: t, title: t.name))
+                    .toList(),
+                selected: _selectedTask == null
+                    ? null
+                    : PickerItem(value: _selectedTask!, title: _selectedTask!.name),
+                onSelected: (item) => _selectTask(item.value),
+                onClear: () => _selectTask(null),
+                onCreate: _selectedProject == null ? null : _createTask,
               ),
-              initialValue: _selectedTaskId,
-              items: [
-                const DropdownMenuItem<int>(value: null, child: Text('No task')),
-                ...tasksState.tasks.map(
-                  (t) => DropdownMenuItem<int>(value: t.id, child: Text(t.name)),
+              const SizedBox(height: AppSpacing.md),
+              TextField(
+                controller: _notesController,
+                textInputAction: TextInputAction.done,
+                decoration: InputDecoration(
+                  labelText: requirementsAsync.valueOrNull?.requireDescription == true
+                      ? 'Notes *'
+                      : 'Notes (optional)',
+                  prefixIcon: const Icon(Icons.note_outlined),
+                ),
+                maxLines: 3,
+              ),
+              if (timerState.error != null) ...[
+                const SizedBox(height: AppSpacing.md),
+                Container(
+                  padding: const EdgeInsets.all(AppSpacing.md),
+                  decoration: BoxDecoration(
+                    color: cs.errorContainer,
+                    borderRadius: AppRadii.brMd,
+                  ),
+                  child: Text(
+                    timerState.error!,
+                    style: TextStyle(color: cs.onErrorContainer),
+                  ),
                 ),
               ],
-              onChanged: _selectedProjectId == null
-                  ? null
-                  : (value) {
-                      setState(() {
-                        _selectedTaskId = value;
-                      });
-                    },
-            ),
-            const SizedBox(height: AppSpacing.md),
-            TextField(
-              controller: _notesController,
-              textInputAction: TextInputAction.done,
-              decoration: InputDecoration(
-                labelText: requirementsAsync.valueOrNull?.requireDescription == true
-                    ? 'Notes *'
-                    : 'Notes (optional)',
-                prefixIcon: const Icon(Icons.note_outlined),
-              ),
-              maxLines: 3,
-            ),
-            if (timerState.error != null) ...[
-              const SizedBox(height: AppSpacing.md),
-              Container(
-                padding: const EdgeInsets.all(AppSpacing.md),
-                decoration: BoxDecoration(
-                  color: cs.errorContainer,
-                  borderRadius: AppRadii.brMd,
-                ),
-                child: Text(
-                  timerState.error!,
-                  style: TextStyle(color: cs.onErrorContainer),
-                ),
+              const SizedBox(height: AppSpacing.lg),
+              Row(
+                children: [
+                  Expanded(
+                    child: TextButton(
+                      onPressed: (timerState.isLoading || isApiLoading) ? null : () => Navigator.of(context).pop(),
+                      child: const Text('Cancel'),
+                    ),
+                  ),
+                  const SizedBox(width: AppSpacing.sm),
+                  Expanded(
+                    child: FilledButton.icon(
+                      onPressed: canStart ? _handleStart : null,
+                      icon: timerState.isLoading
+                          ? const SizedBox(
+                              width: 18,
+                              height: 18,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Icon(Icons.play_arrow),
+                      label: const Text('Start'),
+                    ),
+                  ),
+                ],
               ),
             ],
-            const SizedBox(height: AppSpacing.lg),
-            Row(
-              children: [
-                Expanded(
-                  child: TextButton(
-                    onPressed: (timerState.isLoading || isApiLoading) ? null : () => Navigator.of(context).pop(),
-                    child: const Text('Cancel'),
-                  ),
-                ),
-                const SizedBox(width: AppSpacing.sm),
-                Expanded(
-                  child: FilledButton.icon(
-                    onPressed: canStart ? _handleStart : null,
-                    icon: timerState.isLoading
-                        ? const SizedBox(
-                            width: 18,
-                            height: 18,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : const Icon(Icons.play_arrow),
-                    label: const Text('Start'),
-                  ),
-                ),
-              ],
-            ),
-          ],
+          ),
         ),
       ),
     );

--- a/mobile/lib/presentation/widgets/start_timer_sheet.dart
+++ b/mobile/lib/presentation/widgets/start_timer_sheet.dart
@@ -139,9 +139,13 @@ class _StartTimerSheetState extends ConsumerState<StartTimerSheet> {
   void _selectClient(_ClientItem? client) {
     setState(() {
       _selectedClient = client;
-      // Changing the client invalidates project and task selections.
-      _selectedProject = null;
-      _selectedTask = null;
+      // Changing the client invalidates project and task selections unless
+      // the project belongs to the newly selected client.
+      if (_selectedProject != null &&
+          (client == null || _selectedProject!.clientId != client.id)) {
+        _selectedProject = null;
+        _selectedTask = null;
+      }
     });
   }
 
@@ -149,6 +153,16 @@ class _StartTimerSheetState extends ConsumerState<StartTimerSheet> {
     setState(() {
       _selectedProject = project;
       _selectedTask = null;
+      // Picking a project directly fills in its client automatically.
+      if (project != null &&
+          project.clientId != null &&
+          _selectedClient?.id != project.clientId) {
+        final match =
+            _clients.where((c) => c.id == project.clientId).toList();
+        _selectedClient = match.isNotEmpty
+            ? match.first
+            : _ClientItem(id: project.clientId!, name: project.client ?? '');
+      }
     });
     if (project != null) {
       ref.read(tasksProvider.notifier).loadTasks(projectId: project.id);
@@ -163,7 +177,6 @@ class _StartTimerSheetState extends ConsumerState<StartTimerSheet> {
     if (_selectedClient == null) return projects;
     return projects.where((p) => p.clientId == _selectedClient!.id).toList();
   }
-
   // The v1 create endpoints wrap the payload: {"message": ..., "<key>": {...}}.
   Map<String, dynamic> _unwrap(Map<String, dynamic> res, String key) {
     final nested = res[key];
@@ -408,16 +421,15 @@ class _StartTimerSheetState extends ConsumerState<StartTimerSheet> {
               ),
               const SizedBox(height: AppSpacing.md),
               SearchablePickerField<Project>(
-                key: ValueKey('projects_${_selectedClient?.id}'),
                 label: _selectedClient == null
-                    ? 'Project (select a client first)'
+                    ? 'Project (pick a client or project)'
                     : 'Project (optional for this client)',
                 icon: Icons.folder_outlined,
                 searchHint: 'Search projects',
                 emptyText: _selectedClient == null
-                    ? 'Select a client first'
+                    ? 'No projects found'
                     : 'No projects for this client',
-                enabled: _selectedClient != null && !_creating,
+                enabled: !_creating,
                 isLoading: projectsState.isLoading,
                 error: projectsState.error,
                 onRetry: () => ref.read(projectsProvider.notifier).loadProjects(),
@@ -437,11 +449,12 @@ class _StartTimerSheetState extends ConsumerState<StartTimerSheet> {
                       ),
                 onSelected: (item) => _selectProject(item.value),
                 onClear: () => _selectProject(null),
+                // Creating a project requires a client (mirrors the web app,
+                // which hides Create project until a client is chosen).
                 onCreate: _selectedClient == null ? null : _createProject,
               ),
               const SizedBox(height: AppSpacing.md),
               SearchablePickerField<task_model.Task>(
-                key: ValueKey('tasks_${_selectedProject?.id}'),
                 label: requirementsAsync.valueOrNull?.requireTask == true
                     ? 'Task *'
                     : 'Task (optional)',

--- a/mobile/test/models_test.dart
+++ b/mobile/test/models_test.dart
@@ -66,6 +66,22 @@ void main() {
       expect(project.client, 'Test Client');
       expect(project.status, 'active');
     });
+
+    test('parses last_used_at', () {
+      final project = Project.fromJson({
+        'id': 1,
+        'name': 'Test Project',
+        'last_used_at': '2026-08-27T10:00:00Z',
+      });
+
+      expect(project.lastUsedAt, DateTime.parse('2026-08-27T10:00:00Z'));
+    });
+
+    test('last_used_at defaults to null when absent', () {
+      final project = Project.fromJson({'id': 1, 'name': 'Test Project'});
+
+      expect(project.lastUsedAt, isNull);
+    });
   });
 
   group('Task', () {


### PR DESCRIPTION
## Description

Improves the mobile app's start-timer experience and fixes several bugs found along the way.

**Start timer flow (mobile):**
- Client, project, and task selection now use one consistent searchable picker widget (previously a mix of `DropdownButtonFormField` and `SearchBar`, which made the steps look different)
- Step-by-step cascading selection: the project picker only offers projects of the selected client, and the task picker only tasks of the selected project
- Typing a name that doesn't exist offers an inline **"Create …"** option for clients, projects, and tasks, using the existing `/api/v1` create endpoints — no backend changes needed
- Projects screen is sorted by most recently used (`last_used_at`, already returned by the API) so the last project booked can be restarted with one tap

**Bug fixes (mobile):**
- **Red screen when opening the start timer sheet:** two `FloatingActionButton`s with the default Hero tag coexisted in the home screen's `IndexedStack`, crashing any route pushed on top; the Entries tab FAB now has a unique `heroTag`
- **Inline creation not selecting the new item:** the v1 create endpoints wrap the payload (`{"message": …, "<entity>": {…}}`); the sheet now unwraps it so a created client/project/task is selected immediately
- **Stop/Pause buttons flashing disabled:** background timer polling every 5 s toggled `isLoading`, disabling the buttons during each sync; polls now run silently and `isLoading` is reserved for user-initiated actions

All changes are in `mobile/` only — no backend, database, or web changes.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor (no functional change)

## Checklist

- [x] My code follows the project's style guidelines (Black, flake8). *(N/A for this PR — Dart/Flutter only; code follows the existing mobile patterns, `flutter analyze` is clean for all touched files)*
- [x] I have added/updated tests for my changes. *(added `last_used_at` parsing tests in `mobile/test/models_test.dart`)*
- [x] All tests pass locally (e.g. `pytest`). *(all 9 `flutter test` tests pass)*
- [x] I have updated the documentation if needed. *(no API or setup changes; documented in CHANGELOG instead)*
- [x] For user-facing changes, I have added an entry to the **Unreleased** section of [CHANGELOG.md](../CHANGELOG.md).

## Related issues

_None found for these specific problems — happy to split into issues if preferred._