### PR TITLE
chore(release): bump version to 5.13.4 and update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.13.4] - 2026-09-04
+
+### Fixed
+
+- **Alembic multiple heads** — Parallel migrations `183_add_device_token_push_subscription` and `183_add_idle_needs_review` both branched from `182_add_project_last_used_at`, so `flask db upgrade` failed with multiple heads. No-op merge migration `184_merge_183_heads` rejoins them into a single head.
+
+### Changed
+
+- **Client versions** — Synced Electron (`desktop/package.json`), Flutter (`mobile/pubspec.yaml`), and Chromium extension (`browser-extension/manifest.json` / `package.json`) to **5.13.4** with the webapp (`setup.py`).
+
+### Documentation
+
+- **Version** — Bumped `setup.py` to **5.13.4** (single source of truth for the application version).
+
 ## [5.13.3] - 2026-09-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ TimeTracker has been continuously enhanced with powerful new features! Here's wh
 
 **Current version** is defined in `setup.py` (single source of truth). See [CHANGELOG.md](CHANGELOG.md) for versioned release history.
 
+### ✨ Highlights of v5.13.4
+
+**Patch (5.13.4):** **Alembic multiple heads** — merge migration `184_merge_183_heads` rejoins the parallel `183` device-token and idle needs-review branches so `flask db upgrade` has a single head. See [CHANGELOG.md](CHANGELOG.md#5134---2026-09-04).
+
 ### ✨ Highlights of v5.13.3
 
 **Patch (5.13.3):** **Tracked hours on tasks (#745)** — list, detail, and CSV export show aggregated tracked time. **Idle needs-review** — unanswered idle timers are flagged for review (banner, push, API) instead of lost. **Idle timeout (#722)** — extension heartbeats and mobile FCM wake-up keep Still working? reliable. **Graceful offline (#746)** — JSON offline API responses, toast dedupe, and chat backoff when the backend drops. **Onboarding tour** — skip confirmation stays dismissible. **Datetime format** — workday and CRM fields honor the chosen time format via Flatpickr. See [CHANGELOG.md](CHANGELOG.md#5133---2026-09-02).

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -1,10 +1,18 @@
 {
   "manifest_version": 3,
   "name": "TimeTracker Timer",
-  "version": "5.13.3",
+  "version": "5.13.4",
   "description": "Start and stop TimeTracker timers from your browser toolbar.",
-  "permissions": ["storage", "alarms", "idle", "notifications"],
-  "optional_host_permissions": ["http://*/*", "https://*/*"],
+  "permissions": [
+    "storage",
+    "alarms",
+    "idle",
+    "notifications"
+  ],
+  "optional_host_permissions": [
+    "http://*/*",
+    "https://*/*"
+  ],
   "background": {
     "service_worker": "background.js",
     "type": "module"

--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "timetracker-browser-extension",
   "private": true,
-  "version": "5.13.3",
+  "version": "5.13.4",
   "description": "TimeTracker Chromium extension (Manifest V3)",
   "type": "module",
   "scripts": {

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "timetracker-desktop",
-  "version": "5.13.2",
+  "version": "5.13.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "timetracker-desktop",
-      "version": "5.13.2",
+      "version": "5.13.4",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.18.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timetracker-desktop",
-  "version": "5.13.3",
+  "version": "5.13.4",
   "description": "TimeTracker desktop app for Windows, Linux, and macOS",
   "main": "src/main/main.js",
   "scripts": {

--- a/docs/mobile-desktop-apps/DESKTOP_WEBAPP_GAP.md
+++ b/docs/mobile-desktop-apps/DESKTOP_WEBAPP_GAP.md
@@ -6,9 +6,9 @@ Living checklist for bringing the Electron desktop client up to speed with the F
 
 | Component | Version | Source |
 |-----------|---------|--------|
-| Web / backend | 5.13.3 | `setup.py` |
-| Desktop | 5.13.3 | `desktop/package.json` |
-| Mobile | 5.13.3 | `mobile/pubspec.yaml` |
+| Web / backend | 5.13.4 | `setup.py` |
+| Desktop | 5.13.4 | `desktop/package.json` |
+| Mobile | 5.13.4 | `mobile/pubspec.yaml` |
 
 ## What desktop has
 

--- a/migrations/versions/184_merge_183_heads.py
+++ b/migrations/versions/184_merge_183_heads.py
@@ -1,0 +1,26 @@
+"""Merge the two parallel 183 migration heads into one.
+
+183_add_device_token_push_subscription and 183_add_idle_needs_review were
+both authored off 182_add_project_last_used_at as independent branches,
+giving two heads and breaking flask db upgrade. This no-op merge rejoins
+them into a single head.
+
+Revision ID: 184_merge_183_heads
+Revises: 183_add_device_token_push_subscription, 183_add_idle_needs_review
+"""
+
+revision = "184_merge_183_heads"
+down_revision = (
+    "183_add_device_token_push_subscription",
+    "183_add_idle_needs_review",
+)
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/mobile/android/local.properties
+++ b/mobile/android/local.properties
@@ -1,5 +1,5 @@
-flutter.versionCode=51200
-flutter.versionName=5.12.0
+flutter.versionCode=51304
+flutter.versionName=5.13.4
 flutter.sdk=C:\\Flutter\\flutter
 sdk.dir=C:\\Users\\dries\\AppData\\Local\\Android\\Sdk
 flutter.buildMode=release

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,7 +1,7 @@
 name: timetracker_mobile
 description: TimeTracker mobile app for Android and iOS
 publish_to: 'none'
-version: 5.13.3+1
+version: 5.13.4+1
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='timetracker',
-    version='5.13.3',
+    version='5.13.4',
     packages=find_packages(),
     include_package_data=True,
     package_data={


### PR DESCRIPTION
Document the Alembic 183 dual-head merge migration and sync desktop, mobile, and extension versions with setup.py.

## Description

Brief description of the change and why it's needed.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor (no functional change)

## Checklist

- [ ] My code follows the project's style guidelines (Black, flake8).
- [ ] I have added/updated tests for my changes.
- [ ] All tests pass locally (e.g. `pytest`).
- [ ] I have updated the documentation if needed.
- [ ] For user-facing changes, I have added an entry to the **Unreleased** section of [CHANGELOG.md](../CHANGELOG.md).

## Related issues

Fixes # (issue number, if applicable)

---

See [CONTRIBUTING.md](../CONTRIBUTING.md) and [CHANGELOG.md](../CHANGELOG.md) for guidelines.
