### PR TITLE
fix(idle): exclude paused timers from the idle auto-stop sweep

### DIFF
--- a/app/utils/scheduled_tasks.py
+++ b/app/utils/scheduled_tasks.py
@@ -929,6 +929,10 @@ def check_idle_timers():
         stale = (
             TimeEntry.query.filter(
                 TimeEntry.end_time.is_(None),
+                # A paused timer is intentionally accumulating no time, so the idle
+                # sweep must never notify or auto-stop it. ``paused_at`` was added
+                # with the pause/resume feature but not wired into this query.
+                TimeEntry.paused_at.is_(None),
                 db.or_(
                     TimeEntry.last_heartbeat_at < cutoff,
                     db.and_(

--- a/tests/test_idle_timer_skips_paused.py
+++ b/tests/test_idle_timer_skips_paused.py
@@ -1,0 +1,54 @@
+"""Regression tests for the server-side idle sweep and paused timers.
+
+A paused timer is intentionally accumulating no time, so ``check_idle_timers``
+must never idle-notify, flag, or auto-stop it. The idle query guards
+``TimeEntry.paused_at`` to make that true.
+"""
+
+from datetime import timedelta
+
+from app import db
+from app.models.time_entry import TimeEntry, local_now
+from app.utils.scheduled_tasks import check_idle_timers
+
+
+def _make_stale_active_timer(user, project, *, paused):
+    """An open timer whose last heartbeat is well past the idle window."""
+    now = local_now()
+    timer = TimeEntry(
+        user_id=user.id,
+        project_id=project.id,
+        start_time=now - timedelta(hours=3),
+        source="auto",
+        billable=True,
+    )
+    # Two hours idle — comfortably beyond the 30-minute default window.
+    timer.last_heartbeat_at = now - timedelta(hours=2)
+    if paused:
+        timer.paused_at = now - timedelta(minutes=90)
+    db.session.add(timer)
+    db.session.commit()
+    db.session.refresh(timer)
+    return timer
+
+
+def test_idle_sweep_skips_paused_timer(app, user, project):
+    paused = _make_stale_active_timer(user, project, paused=True)
+
+    check_idle_timers()
+    db.session.refresh(paused)
+
+    # A paused timer must not be idle-notified, flagged, or stopped.
+    assert paused.idle_notified_at is None
+    assert paused.idle_flagged_at is None
+    assert paused.end_time is None
+
+
+def test_idle_sweep_still_notifies_running_timer(app, user, project):
+    """Control: a genuinely idle, non-paused timer is still swept."""
+    running = _make_stale_active_timer(user, project, paused=False)
+
+    check_idle_timers()
+    db.session.refresh(running)
+
+    assert running.idle_notified_at is not None


### PR DESCRIPTION
## Problem

`check_idle_timers()` selects every open time entry (`end_time IS NULL`) whose last heartbeat is older than the idle window, then idle-notifies it, flags it `needs_review`, and — with the safety cap enabled — auto-stops it.

A **paused** timer is also an open entry with a stale heartbeat: it is intentionally accumulating no time and sends no heartbeats while paused. So the sweep treats a deliberately-paused timer exactly like an abandoned running one — it fires the "Still working?" push, flags it for review, and can auto-stop a timer the user chose to pause.

## Root cause

`paused_at` was added with the pause/resume feature but never wired into the idle-sweep query. The `WHERE` clause guards only `end_time` and the heartbeat cutoff, so paused rows fall straight through.

## Fix

Add `TimeEntry.paused_at.is_(None)` to the idle query so paused timers are excluded from notify / flag / auto-stop. Four added lines, no behavioral change for running timers.

## Tests

New `tests/test_idle_timer_skips_paused.py`:

- `test_idle_sweep_skips_paused_timer` — a paused, stale timer is neither notified, flagged, nor stopped.
- `test_idle_sweep_still_notifies_running_timer` — control: a genuinely idle, non-paused timer is still swept, guarding against over-correction.

Full timer test suite green locally.
