### PR TITLE
fix(manual-entry): restore single-client lock by dropping force_selectable

### DIFF
--- a/app/templates/timer/manual_entry.html
+++ b/app/templates/timer/manual_entry.html
@@ -106,7 +106,7 @@
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                         <div>
                             <label for="client_id" class="block text-sm font-medium text-text-light dark:text-text-dark">{{ _('Client') }}</label>
-                            {{ client_select('client_id', clients, selected_id=selected_client_id, required=False, only_one_client=false, single_client=none, searchable=True, force_selectable=True, can_create=can_create_clients|default(false)) }}
+                            {{ client_select('client_id', clients, selected_id=selected_client_id, required=False, only_one_client=false, single_client=none, searchable=True, can_create=can_create_clients|default(false)) }}
                             <p class="text-xs text-text-muted-light dark:text-text-muted-dark mt-1">{{ _('Select a client first, then optionally a project. Type to search or create.') }}</p>
                         </div>
                         <div>


### PR DESCRIPTION
## Problem

On the manual time-entry form, an organization with exactly one client sees a full searchable `<select>` for the client field instead of the readonly, pre-filled control the single-client UX calls for. This also makes the existing regression test `test_manual_entry_shows_single_client_prefilled` fail on a clean checkout (`assert 'readonly' in html`).

## Root cause

`manual_entry.html` passes `force_selectable=True` to the `client_select` macro. That flag short-circuits all three single-client-lock branches in `components/client_select.html`, so the 1-client case never renders the locked, pre-filled input.

## Fix

Drop `force_selectable=True` from the macro call. The `searchable` and `can_create` arguments continue to serve the 0- and 2+-client cases; only the single-client lock is restored. One-line change.

## Tests

`tests/test_client_single_simplification.py` (already in the tree) now passes:

- `test_manual_entry_shows_single_client_prefilled`
- `test_manual_entry_shows_select_when_multiple_clients`

Ran the seven manual_entry-related suites together (76 tests) — all green, no regressions.
